### PR TITLE
Add publish to NuGet job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,7 @@ stages:
     #     testRunTitle: IntegrationTests
 
 - stage: ProGet
-  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   variables:
   - group: nuget-deployment-vars
   jobs:
@@ -206,7 +206,7 @@ stages:
             displayName: Publish Package
 
 - stage: NuGet
-  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   variables:
   - group: nuget-deployment-vars
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,7 @@ stages:
     #     testRunTitle: IntegrationTests
 
 - stage: ProGet
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   variables:
   - group: nuget-deployment-vars
   jobs:
@@ -203,4 +203,34 @@ stages:
           - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(progetApiKey) -s https://progetcloud.ukho.gov.uk/nuget/ukho.trusted/v3/index.json }
             env:
               progetApiKey : $(progetApiKey)
+            displayName: Publish Package
+
+- stage: NuGet
+  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  variables:
+  - group: nuget-deployment-vars
+  jobs:
+  - deployment: Publish_To_NuGet
+    displayName: Publish To NuGet
+    pool:
+      name: NautilusRelease
+    environment: UKHO-ADDS-Clients-NuGet
+    workspace:
+      clean: all
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - task: UseDotNet@2
+            displayName: 'Use .NET $(SdkVersion) sdk'
+            inputs:
+              packageType: sdk
+              version: $(SdkVersion)
+
+          - download: current
+            artifact: NuGetPackages
+
+          - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(nugetapikey) -s https://api.nuget.org/v3/index.json --no-symbols}
+            env:
+              nugetApiKey : $(nugetapikey)
             displayName: Publish Package

--- a/src/UKHO.ADDS.Clients.Common/UKHO.ADDS.Clients.Common.csproj
+++ b/src/UKHO.ADDS.Clients.Common/UKHO.ADDS.Clients.Common.csproj
@@ -7,6 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/UKHO/UKHO.ADDS.Clients</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UKHO/UKHO.ADDS.Clients</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,4 +25,9 @@
     <PackageReference Include="UKHO.ADDS.Infrastructure.Results" Version="0.0.50312-alpha.1" />
     <PackageReference Include="UKHO.ADDS.Infrastructure.Serialization" Version="0.0.50312-alpha.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+  
 </Project>

--- a/src/UKHO.ADDS.Clients.FileShareService.ReadOnly/UKHO.ADDS.Clients.FileShareService.ReadOnly.csproj
+++ b/src/UKHO.ADDS.Clients.FileShareService.ReadOnly/UKHO.ADDS.Clients.FileShareService.ReadOnly.csproj
@@ -7,6 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/UKHO/UKHO.ADDS.Clients</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UKHO/UKHO.ADDS.Clients</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +25,10 @@
     <InternalsVisibleTo Include="UKHO.ADDS.Clients.FileShareService.ReadWrite" />
     <InternalsVisibleTo Include="UKHO.ADDS.Clients.FileShareService.ReadOnly.Tests" />
     <InternalsVisibleTo Include="UKHO.ADDS.Clients.FileShareService.ReadWrite.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/UKHO.ADDS.Clients.FileShareService.ReadWrite/UKHO.ADDS.Clients.FileShareService.ReadWrite.csproj
+++ b/src/UKHO.ADDS.Clients.FileShareService.ReadWrite/UKHO.ADDS.Clients.FileShareService.ReadWrite.csproj
@@ -7,6 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/UKHO/UKHO.ADDS.Clients</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UKHO/UKHO.ADDS.Clients</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +16,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\UKHO.ADDS.Clients.FileShareService.ReadOnly\UKHO.ADDS.Clients.FileShareService.ReadOnly.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/UKHO.ADDS.Clients.PermitService/UKHO.ADDS.Clients.PermitService.csproj
+++ b/src/UKHO.ADDS.Clients.PermitService/UKHO.ADDS.Clients.PermitService.csproj
@@ -7,6 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/UKHO/UKHO.ADDS.Clients</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UKHO/UKHO.ADDS.Clients</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +17,10 @@
   <ItemGroup>
     <PackageReference Include="UKHO.ADDS.Infrastructure.Results" Version="0.0.50312-alpha.1" />
     <PackageReference Include="UKHO.ADDS.Infrastructure.Serialization" Version="0.0.50312-alpha.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/UKHO.ADDS.Clients.SalesCatalogueService.csproj
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/UKHO.ADDS.Clients.SalesCatalogueService.csproj
@@ -7,6 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/UKHO/UKHO.ADDS.Clients</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UKHO/UKHO.ADDS.Clients</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +18,10 @@
     <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="UKHO.ADDS.Infrastructure.Results" Version="0.0.50312-alpha.1" />
     <PackageReference Include="UKHO.ADDS.Infrastructure.Serialization" Version="0.0.50312-alpha.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#### PR Classification
New feature for Azure Pipelines to enhance NuGet package publishing.

#### PR Summary
This pull request adds a new stage in the Azure Pipelines configuration for publishing NuGet packages, conditioned to run on the main branch after successful builds. It also updates multiple project files to include a README.md file in the package. 
- **azure-pipelines.yml**: Introduces a new stage for publishing NuGet packages with deployment steps.
- **UKHO.ADDS.Clients.Common.csproj**: Adds a reference to README.md for packaging.
- **UKHO.ADDS.Clients.FileShareService.ReadOnly.csproj**: Adds a reference to README.md for packaging.
- **UKHO.ADDS.Clients.FileShareService.ReadWrite.csproj**: Adds a reference to README.md for packaging.
- **UKHO.ADDS.Clients.PermitService.csproj**: Adds a reference to README.md for packaging.
