### PR TITLE
Add clients for SCS (Get S100 Catalogue Endpoint) and Permit Service Endpoint

### DIFF
--- a/src/UKHO.ADDS.Clients.Common/Constants/ApiHeaderKeys.cs
+++ b/src/UKHO.ADDS.Clients.Common/Constants/ApiHeaderKeys.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace UKHO.ADDS.Clients.Common.Constants
+{
+    [ExcludeFromCodeCoverage]
+    public static class ApiHeaderKeys
+    {
+        public const string ErrorOrigin = "X-Error-Origin";
+        public const string BearerTokenHeaderKey = "bearer";
+        public const string XCorrelationIdHeaderKey = "X-Correlation-ID";        
+    }
+}

--- a/src/UKHO.ADDS.Clients.Common/Constants/ApiNames.cs
+++ b/src/UKHO.ADDS.Clients.Common/Constants/ApiNames.cs
@@ -3,7 +3,7 @@
 namespace UKHO.ADDS.Clients.Common.Constants
 {
     [ExcludeFromCodeCoverage]
-    public static class Applications
+    public static class ApiNames
     {
         public const string FileShareService = "FSS";
         public const string PermitService = "PermitService";

--- a/src/UKHO.ADDS.Clients.Common/Constants/Applications.cs
+++ b/src/UKHO.ADDS.Clients.Common/Constants/Applications.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace UKHO.ADDS.Clients.Common.Constants
+{
+    [ExcludeFromCodeCoverage]
+    public static class Applications
+    {
+        public const string FileShareService = "FSS";
+        public const string PermitService = "PermitService";
+        public const string SaleCatalogueService = "SCS";
+    }
+}

--- a/src/UKHO.ADDS.Clients.Common/Constants/ErrorMetaDataKeys.cs
+++ b/src/UKHO.ADDS.Clients.Common/Constants/ErrorMetaDataKeys.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace UKHO.ADDS.Clients.Common.Constants
+{
+    [ExcludeFromCodeCoverage]
+    public static class ErrorMetaDataKeys
+    {
+        public const string ErrorOrigin = "ErrorOrigin";
+        public const string ErrorResponseBody = "ErrorResponse";
+    }
+}

--- a/src/UKHO.ADDS.Clients.Common/Extensions/HttpClientExtensions.cs
+++ b/src/UKHO.ADDS.Clients.Common/Extensions/HttpClientExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http.Headers;
 using UKHO.ADDS.Clients.Common.Authentication;
+using UKHO.ADDS.Clients.Common.Constants;
 
 namespace UKHO.ADDS.Clients.Common.Extensions
 {
@@ -14,7 +15,18 @@ namespace UKHO.ADDS.Clients.Common.Extensions
         public static async Task SetAuthenticationHeaderAsync(this HttpClient httpClient, IAuthenticationTokenProvider authTokenProvider)
         {
             var token = await authTokenProvider.GetTokenAsync();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", token);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(ApiHeaderKeys.BearerTokenHeaderKey, token);
+        }
+
+        /// <summary>
+        /// Sets CorrelationId in request header
+        /// </summary>
+        /// <param name="httpClient"></param>
+        /// <param name="correlationId"></param>
+        /// <returns></returns>
+        public static void SetCorrelationIdHeaderAsync(this HttpClient httpClient, string correlationId)
+        {
+            httpClient.DefaultRequestHeaders.Add(ApiHeaderKeys.XCorrelationIdHeaderKey, correlationId);
         }
     }
 }

--- a/src/UKHO.ADDS.Clients.Common/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/UKHO.ADDS.Clients.Common/Extensions/HttpResponseMessageExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using UKHO.ADDS.Clients.Common.Constants;
 using UKHO.ADDS.Infrastructure.Results;
 using UKHO.ADDS.Infrastructure.Serialization.Json;
 
@@ -50,6 +51,33 @@ namespace UKHO.ADDS.Clients.Common.Extensions
             }
         }
 
+        public static async Task<IResult<TValue>> CreateResultAsync<TValue>(this HttpResponseMessage response, string applicationName) where TValue : class
+        {
+            try
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    if (typeof(TValue).IsAssignableTo(typeof(Stream)))
+                    {
+                        var stream = await response.Content.ReadAsStreamAsync();
+                        return Result.Success(stream as TValue);
+                    }
+
+                    var bodyJson = await response.Content.ReadAsStringAsync();
+                    var body = JsonCodec.Decode<TValue>(bodyJson);
+
+                    return Result.Success(body);
+                }
+
+                var errorMetadata = await CreateErrorMetadata(response, applicationName);
+                return Result.Failure<TValue>(ErrorFactory.CreateError(response.StatusCode, errorMetadata));
+            }
+            catch (Exception ex)
+            {
+                return Result.Failure<TValue>(ex);
+            }
+        }
+
         public static async Task<Result<TValue>> CreateResultAsync<TValue, TError>(this HttpResponseMessage response, Func<TError, HttpStatusCode, IError> errorFunc) where TValue : class
         {
             try
@@ -86,6 +114,20 @@ namespace UKHO.ADDS.Clients.Common.Extensions
             }
         }
 
+        private static async Task<IDictionary<string, object>> CreateErrorMetadata(HttpResponseMessage response, string applicationName)
+        {
+            IDictionary<string, object> errorMetadata = new Dictionary<string, object>();
+
+            //get error origin from http response
+            var origin = response.Headers.TryGetValues(ApiHeaderKeys.ErrorOrigin, out var value) ? value.FirstOrDefault() : applicationName;
+            //get error response body
+            var errorJson = await response.Content.ReadAsStringAsync();
+
+            errorMetadata.Add(ErrorMetaDataKeys.ErrorOrigin, origin ?? applicationName);
+            errorMetadata.Add(ErrorMetaDataKeys.ErrorResponseBody, errorJson);
+
+            return errorMetadata;
+        }
         private static bool HasContent(this HttpResponseMessage response) => response.Content.GetType().Name != "EmptyContent";
     }
 }

--- a/src/UKHO.ADDS.Clients.PermitService/IPermitClient.cs
+++ b/src/UKHO.ADDS.Clients.PermitService/IPermitClient.cs
@@ -1,7 +1,10 @@
-﻿namespace UKHO.ADDS.Clients.PermitService
+﻿using UKHO.ADDS.Clients.PermitService.Models;
+using UKHO.ADDS.Infrastructure.Results;
+
+namespace UKHO.ADDS.Clients.PermitService
 {
     public interface IPermitClient
     {
-        
+        public Task<IResult<Stream>> GetPermitAsync(string apiVersion, string productType, PermitRequest requestBody,string correlationId);
     }
 }

--- a/src/UKHO.ADDS.Clients.PermitService/Models/PermitRequest.cs
+++ b/src/UKHO.ADDS.Clients.PermitService/Models/PermitRequest.cs
@@ -1,0 +1,16 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+
+namespace UKHO.ADDS.Clients.PermitService.Models
+{
+    [ExcludeFromCodeCoverage]
+    public class PermitRequest
+    {
+        [JsonPropertyName("products")]
+        public IEnumerable<Product>? Products { get; set; }
+
+        [JsonPropertyName("userPermits")]
+        public IEnumerable<UserPermit>? UserPermits { get; set; }
+    }
+}

--- a/src/UKHO.ADDS.Clients.PermitService/Models/Product.cs
+++ b/src/UKHO.ADDS.Clients.PermitService/Models/Product.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace UKHO.ADDS.Clients.PermitService.Models
+{
+    [ExcludeFromCodeCoverage]
+    public class Product
+    {
+        [JsonPropertyName("productName")]
+        public string? ProductName { get; set; }
+
+        [JsonPropertyName("editionNumber")]
+        public int? EditionNumber { get; set; }
+
+        [JsonPropertyName("permitExpiryDate")]
+        public string? PermitExpiryDate { get; set; }
+    }
+}

--- a/src/UKHO.ADDS.Clients.PermitService/Models/UserPermit.cs
+++ b/src/UKHO.ADDS.Clients.PermitService/Models/UserPermit.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace UKHO.ADDS.Clients.PermitService.Models
+{
+    [ExcludeFromCodeCoverage]
+    public class UserPermit
+    {
+        public string? Title { get; set; }
+        public string? Upn { get; set; }
+    }
+}

--- a/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
+++ b/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
@@ -12,7 +12,7 @@ namespace UKHO.ADDS.Clients.PermitService
     public class PermitClient : IPermitClient
     {
         private readonly IAuthenticationTokenProvider _authTokenProvider;
-        private readonly IHttpClientFactory _httpClientFactory;        
+        private readonly IHttpClientFactory _httpClientFactory;
 
         public PermitClient(IHttpClientFactory httpClientFactory, string baseAddress, IAuthenticationTokenProvider authTokenProvider)
         {
@@ -23,12 +23,12 @@ namespace UKHO.ADDS.Clients.PermitService
         public PermitClient(IHttpClientFactory httpClientFactory, string baseAddress, string accessToken) :
             this(httpClientFactory, baseAddress, new DefaultAuthenticationTokenProvider(accessToken))
         {
-        }        
+        }
 
         public async Task<IResult<Stream>> GetPermitAsync(string apiVersion, string productType, PermitRequest requestBody,
             string correlationId)
         {
-            var uri = $"/{apiVersion}/permits/{Uri.EscapeDataString(productType)}";             
+            var uri = new Uri($"/{apiVersion}/permits/{productType}", UriKind.Relative);
 
             try
             {

--- a/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
+++ b/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
@@ -1,5 +1,11 @@
-﻿using UKHO.ADDS.Clients.Common.Authentication;
+﻿using System.Text.Json;
+using System.Text;
+using UKHO.ADDS.Clients.Common.Authentication;
+using UKHO.ADDS.Clients.Common.Extensions;
 using UKHO.ADDS.Clients.Common.Factories;
+using UKHO.ADDS.Clients.PermitService.Models;
+using UKHO.ADDS.Infrastructure.Results;
+using UKHO.ADDS.Clients.Common.Constants;
 
 namespace UKHO.ADDS.Clients.PermitService
 {
@@ -7,6 +13,7 @@ namespace UKHO.ADDS.Clients.PermitService
     {
         private readonly IAuthenticationTokenProvider _authTokenProvider;
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly HttpClient _httpClient;
 
         public PermitClient(IHttpClientFactory httpClientFactory, string baseAddress, IAuthenticationTokenProvider authTokenProvider)
         {
@@ -19,6 +26,35 @@ namespace UKHO.ADDS.Clients.PermitService
         {
         }
 
+        public PermitClient(HttpClient httpClient, string accessToken)
+        {
+            _httpClient= httpClient;
+            _authTokenProvider = new DefaultAuthenticationTokenProvider(accessToken);
+        }
 
+        public async Task<IResult<Stream>> GetPermitAsync(string apiVersion, string productType, PermitRequest requestBody,
+            string correlationId)
+        {
+            var uri = $"/{apiVersion}/permits/{productType}"; 
+
+            await _httpClient.SetAuthenticationHeaderAsync(_authTokenProvider);
+            _httpClient.SetCorrelationIdHeaderAsync(correlationId);
+
+            try
+            {
+                using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri))
+                {
+                    httpRequestMessage.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
+
+                    var httpResponse = await _httpClient.SendAsync(httpRequestMessage);
+
+                    return await httpResponse.CreateResultAsync<Stream>(Applications.PermitService);                    
+                }
+            }
+            catch (Exception ex)
+            {
+                return Result.Failure<Stream>(ex);
+            }
+        }
     }
 }

--- a/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
+++ b/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
@@ -48,7 +48,7 @@ namespace UKHO.ADDS.Clients.PermitService
 
                     var httpResponse = await _httpClient.SendAsync(httpRequestMessage);
 
-                    return await httpResponse.CreateResultAsync<Stream>(Applications.PermitService);                    
+                    return await httpResponse.CreateResultAsync<Stream>(ApiNames.PermitService, correlationId);                    
                 }
             }
             catch (Exception ex)

--- a/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
+++ b/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
@@ -12,8 +12,7 @@ namespace UKHO.ADDS.Clients.PermitService
     public class PermitClient : IPermitClient
     {
         private readonly IAuthenticationTokenProvider _authTokenProvider;
-        private readonly IHttpClientFactory _httpClientFactory;
-        private readonly HttpClient _httpClient;
+        private readonly IHttpClientFactory _httpClientFactory;        
 
         public PermitClient(IHttpClientFactory httpClientFactory, string baseAddress, IAuthenticationTokenProvider authTokenProvider)
         {
@@ -24,37 +23,38 @@ namespace UKHO.ADDS.Clients.PermitService
         public PermitClient(IHttpClientFactory httpClientFactory, string baseAddress, string accessToken) :
             this(httpClientFactory, baseAddress, new DefaultAuthenticationTokenProvider(accessToken))
         {
-        }
-
-        public PermitClient(HttpClient httpClient, string accessToken)
-        {
-            _httpClient= httpClient;
-            _authTokenProvider = new DefaultAuthenticationTokenProvider(accessToken);
-        }
+        }        
 
         public async Task<IResult<Stream>> GetPermitAsync(string apiVersion, string productType, PermitRequest requestBody,
             string correlationId)
         {
-            var uri = $"/{apiVersion}/permits/{productType}"; 
-
-            await _httpClient.SetAuthenticationHeaderAsync(_authTokenProvider);
-            _httpClient.SetCorrelationIdHeaderAsync(correlationId);
+            var uri = $"/{apiVersion}/permits/{productType}";             
 
             try
             {
-                using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri))
-                {
-                    httpRequestMessage.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
+                using var httpClient = await GetAuthenticatedClientAsync(correlationId);
 
-                    var httpResponse = await _httpClient.SendAsync(httpRequestMessage);
+                using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri);
 
-                    return await httpResponse.CreateResultAsync<Stream>(ApiNames.PermitService, correlationId);                    
-                }
+                httpRequestMessage.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
+
+                var httpResponse = await httpClient.SendAsync(httpRequestMessage);
+
+                return await httpResponse.CreateResultAsync<Stream>(ApiNames.PermitService, correlationId);
             }
             catch (Exception ex)
             {
                 return Result.Failure<Stream>(ex);
             }
+        }
+        protected async Task<HttpClient> GetAuthenticatedClientAsync(string correlationId)
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+
+            await httpClient.SetAuthenticationHeaderAsync(_authTokenProvider);
+            httpClient.SetCorrelationIdHeaderAsync(correlationId);
+
+            return httpClient;
         }
     }
 }

--- a/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
+++ b/src/UKHO.ADDS.Clients.PermitService/PermitClient.cs
@@ -28,7 +28,7 @@ namespace UKHO.ADDS.Clients.PermitService
         public async Task<IResult<Stream>> GetPermitAsync(string apiVersion, string productType, PermitRequest requestBody,
             string correlationId)
         {
-            var uri = $"/{apiVersion}/permits/{productType}";             
+            var uri = $"/{apiVersion}/permits/{Uri.EscapeDataString(productType)}";             
 
             try
             {

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/ISalesCatalogueClient.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/ISalesCatalogueClient.cs
@@ -5,6 +5,7 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService
 {
     public interface ISalesCatalogueClient
     {
+        public Task<IResult<S100SalesCatalogueResponse>> GetS100ProductsFromSpecificDateAsync(string apiVersion, string productType, string sinceDateTime, string correlationId);
         public Task<IResult<SalesCatalogueResponse>> GetProductsFromSpecificDateAsync(string sinceDateTime, string correlationId);
         public Task<IResult<SalesCatalogueResponse>> PostProductIdentifiersAsync(List<string> productIdentifiers, string correlationId);
         public Task<IResult<SalesCatalogueResponse>> PostProductVersionsAsync(List<ProductVersionRequest> productVersions, string correlationId);

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/Models/S100ProductStatus.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/Models/S100ProductStatus.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace UKHO.ADDS.Clients.SalesCatalogueService.Models
+{
+    [ExcludeFromCodeCoverage]
+    public class S100ProductStatus
+    {
+        [JsonPropertyName("statusName")]
+        public string? StatusName { get; set; }
+
+        [JsonPropertyName("statusDate")]
+        public DateTime StatusDate { get; set; }
+    }
+}

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/Models/S100Products.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/Models/S100Products.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace UKHO.ADDS.Clients.SalesCatalogueService.Models
+{
+    [ExcludeFromCodeCoverage]
+    public class S100Products
+    {
+        [JsonPropertyName("productName")]
+        public string? ProductName { get; set; }
+
+        [JsonPropertyName("latestEditionNumber")]
+        public int? LatestEditionNumber { get; set; }
+
+        [JsonPropertyName("latestUpdateNumber")]
+        public int? LatestUpdateNumber { get; set; }
+
+        [JsonPropertyName("status")]
+        public S100ProductStatus? Status { get; set; }
+    }
+}

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/Models/S100SalesCatalogueResponse.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/Models/S100SalesCatalogueResponse.cs
@@ -1,0 +1,12 @@
+﻿using System.Net;
+
+namespace UKHO.ADDS.Clients.SalesCatalogueService.Models
+{
+    public class S100SalesCatalogueResponse
+    {
+        public List<S100Products> ResponseBody { get; set; }
+        public DateTime? LastModified { get; set; }
+        public HttpStatusCode ResponseCode { get; set; }
+
+    }
+}

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using UKHO.ADDS.Clients.Common.Authentication;
+using UKHO.ADDS.Clients.Common.Constants;
 using UKHO.ADDS.Clients.Common.Extensions;
 using UKHO.ADDS.Clients.Common.Factories;
 using UKHO.ADDS.Clients.SalesCatalogueService.Models;
@@ -61,7 +62,7 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService
                     var response = await _httpClient.SendAsync(httpRequestMessage);
 
                     //create response result as per expected output by reading additional values from httpresponse object 
-                    return await CreateS100ProductsFromSpecificDateResponse(response);
+                    return await CreateS100ProductsFromSpecificDateResponse(response,correlationId);
                 }
             }
             catch (Exception ex)
@@ -104,13 +105,14 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService
         /// </summary>
         /// <param name="httpResponseMessage">The HTTP response message.</param>
         /// <returns>The result contains the S100 sales catalogue response.</returns>
-        private async Task<IResult<S100SalesCatalogueResponse>> CreateS100ProductsFromSpecificDateResponse(HttpResponseMessage httpResponseMessage)
+        private async Task<IResult<S100SalesCatalogueResponse>> CreateS100ProductsFromSpecificDateResponse(HttpResponseMessage httpResponseMessage, string correlationId)
         {
             var response = new S100SalesCatalogueResponse();
 
             if (httpResponseMessage.StatusCode != HttpStatusCode.OK && httpResponseMessage.StatusCode != HttpStatusCode.NotModified)
             {
-                return Result.Failure<S100SalesCatalogueResponse>(ErrorFactory.CreateError(httpResponseMessage.StatusCode));
+                var errorMetadata = await httpResponseMessage.CreateErrorMetadata(ApiNames.SaleCatalogueService, correlationId);
+                return Result.Failure<S100SalesCatalogueResponse>(ErrorFactory.CreateError(httpResponseMessage.StatusCode, errorMetadata));
             }
             else
             {

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
@@ -46,7 +46,14 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService
                 //set "If-Modified-Since" header value in request header if value is passed
                 if (!string.IsNullOrEmpty(sinceDateTime))
                 {
-                    httpRequestMessage.Headers.Add("If-Modified-Since", sinceDateTime);
+                    if (DateTime.TryParse(sinceDateTime, out DateTime parsedDate))
+                    {
+                        httpRequestMessage.Headers.Add("If-Modified-Since", parsedDate.ToString("R"));
+                    }
+                    else
+                    {
+                        throw new FormatException("Invalid date format for sinceDateTime.");
+                    }
                 }
 
                 var response = await httpClient.SendAsync(httpRequestMessage);

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
@@ -46,14 +46,7 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService
                 //set "If-Modified-Since" header value in request header if value is passed
                 if (!string.IsNullOrEmpty(sinceDateTime))
                 {
-                    if (DateTime.TryParse(sinceDateTime, out DateTime parsedDate))
-                    {
-                        httpRequestMessage.Headers.Add("If-Modified-Since", parsedDate.ToString("R"));
-                    }
-                    else
-                    {
-                        throw new FormatException("Invalid date format for sinceDateTime.");
-                    }
+                    httpRequestMessage.Headers.Add("If-Modified-Since", sinceDateTime);
                 }
 
                 var response = await httpClient.SendAsync(httpRequestMessage);

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
@@ -35,7 +35,7 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService
         /// <returns>A task that represents the asynchronous operation. The task result contains the S100 sales catalogue response.</returns>
         public async Task<IResult<S100SalesCatalogueResponse>> GetS100ProductsFromSpecificDateAsync(string apiVersion, string productType, string sinceDateTime, string correlationId)
         {
-            var uri = $"/{apiVersion}/catalogues/{Uri.EscapeDataString(productType)}/basic";
+            var uri = new Uri($"/{apiVersion}/catalogues/{productType}/basic", UriKind.Relative);
 
             try
             {

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
@@ -1,8 +1,10 @@
 ﻿using System.Net;
 using UKHO.ADDS.Clients.Common.Authentication;
+using UKHO.ADDS.Clients.Common.Extensions;
 using UKHO.ADDS.Clients.Common.Factories;
 using UKHO.ADDS.Clients.SalesCatalogueService.Models;
 using UKHO.ADDS.Infrastructure.Results;
+using UKHO.ADDS.Infrastructure.Serialization.Json;
 
 namespace UKHO.ADDS.Clients.SalesCatalogueService
 {
@@ -10,11 +12,13 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService
     {
         private readonly IAuthenticationTokenProvider _authTokenProvider;
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly HttpClient _httpClient;
 
         public SalesCatalogueClient(IHttpClientFactory httpClientFactory, string baseAddress, IAuthenticationTokenProvider authTokenProvider)
         {
             _httpClientFactory = new SetBaseAddressHttpClientFactory(httpClientFactory, new Uri(baseAddress));
             _authTokenProvider = authTokenProvider;
+            _httpClient = _httpClientFactory.CreateClient();
         }
 
         public SalesCatalogueClient(IHttpClientFactory httpClientFactory, string baseAddress, string accessToken) :
@@ -22,32 +26,113 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService
         {
         }
 
+        public SalesCatalogueClient(HttpClient httpClient, string accessToken)
+        {
+            _httpClient = httpClient;
+            _authTokenProvider = new DefaultAuthenticationTokenProvider(accessToken);
+            _httpClientFactory = null;
+        }
+
+        /// <summary>
+        /// Retrieves S100 products from a specific date asynchronously.
+        /// </summary>
+        /// <param name="apiVersion">The API version to use.</param>
+        /// <param name="productType">The type of product to retrieve.</param>
+        /// <param name="sinceDateTime">The date and time since when the products are to be retrieved.</param>
+        /// <param name="correlationId">The correlation ID for the request.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the S100 sales catalogue response.</returns>
+        public async Task<IResult<S100SalesCatalogueResponse>> GetS100ProductsFromSpecificDateAsync(string apiVersion, string productType, string sinceDateTime, string correlationId)
+        {
+            var uri = $"/{apiVersion}/catalogues/{productType}/basic";
+
+            await _httpClient.SetAuthenticationHeaderAsync(_authTokenProvider);
+            _httpClient.SetCorrelationIdHeaderAsync(correlationId);
+
+            try
+            {
+                using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri))
+                {
+                    //set "If-Modified-Since" header value in request header if value is passed
+                    if (!string.IsNullOrEmpty(sinceDateTime))
+                    {
+                        httpRequestMessage.Headers.Add("If-Modified-Since", sinceDateTime);
+                    }
+
+                    var response = await _httpClient.SendAsync(httpRequestMessage);
+
+                    //create response result as per expected output by reading additional values from httpresponse object 
+                    return await CreateS100ProductsFromSpecificDateResponse(response);
+                }
+            }
+            catch (Exception ex)
+            {
+                return Result.Failure<S100SalesCatalogueResponse>(ex);
+            }
+        }
+
         public async Task<IResult<SalesCatalogueResponse>> GetProductsFromSpecificDateAsync(string sinceDateTime, string correlationId)
         {
+            // Implementation for GetProductsFromSpecificDateAsync
             return Result.Success(new SalesCatalogueResponse());
         }
 
         public async Task<IResult<SalesCatalogueResponse>> PostProductIdentifiersAsync(List<string> productIdentifiers, string correlationId)
         {
             var code = HttpStatusCode.BadRequest;
-            return Result.Failure<SalesCatalogueResponse>(ErrorFactory.CreateError(code));
+            return await Task.FromResult(Result.Failure<SalesCatalogueResponse>(ErrorFactory.CreateError(code)));
         }
 
         public async Task<IResult<SalesCatalogueResponse>> PostProductVersionsAsync(List<ProductVersionRequest> productVersions, string correlationId)
         {
             try
             {
-                return Result.Success(new SalesCatalogueResponse());
+                return await Task.FromResult(Result.Success(new SalesCatalogueResponse()));
             }
             catch (Exception ex)
             {
-                return Result.Failure<SalesCatalogueResponse>(ex);
+                return await Task.FromResult(Result.Failure<SalesCatalogueResponse>(ex));
             }
         }
 
         public async Task<IResult<SalesCatalogueDataResponse>> GetSalesCatalogueDataResponse(string batchId, string correlationId)
         {
-            return Result.Success(new SalesCatalogueDataResponse());
+            return await Task.FromResult(Result.Success(new SalesCatalogueDataResponse()));
+        }
+
+        /// <summary>
+        /// Creates a response for S100 products retrieved from a specific date.
+        /// </summary>
+        /// <param name="httpResponseMessage">The HTTP response message.</param>
+        /// <returns>The result contains the S100 sales catalogue response.</returns>
+        private async Task<IResult<S100SalesCatalogueResponse>> CreateS100ProductsFromSpecificDateResponse(HttpResponseMessage httpResponseMessage)
+        {
+            var response = new S100SalesCatalogueResponse();
+
+            if (httpResponseMessage.StatusCode != HttpStatusCode.OK && httpResponseMessage.StatusCode != HttpStatusCode.NotModified)
+            {
+                return Result.Failure<S100SalesCatalogueResponse>(ErrorFactory.CreateError(httpResponseMessage.StatusCode));
+            }
+            else
+            {
+                response.ResponseCode = httpResponseMessage.StatusCode;
+
+                if (httpResponseMessage.StatusCode == HttpStatusCode.OK)
+                {
+                    var bodyJson = await httpResponseMessage.Content.ReadAsStringAsync();
+
+                    //Deserialize Json response body to S100Products
+                    var products = JsonCodec.Decode<List<S100Products>>(bodyJson);
+
+                    response.ResponseBody = products ?? new List<S100Products>();
+                }
+
+                var lastModified = httpResponseMessage.Content.Headers.LastModified;
+                if (lastModified != null)
+                {
+                    response.LastModified = ((DateTimeOffset)lastModified).UtcDateTime;
+                }
+            }
+            return Result.Success(response);
         }
     }
 }

--- a/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
+++ b/src/UKHO.ADDS.Clients.SalesCatalogueService/SalesCatalogueClient.cs
@@ -35,7 +35,7 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService
         /// <returns>A task that represents the asynchronous operation. The task result contains the S100 sales catalogue response.</returns>
         public async Task<IResult<S100SalesCatalogueResponse>> GetS100ProductsFromSpecificDateAsync(string apiVersion, string productType, string sinceDateTime, string correlationId)
         {
-            var uri = $"/{apiVersion}/catalogues/{productType}/basic";
+            var uri = $"/{apiVersion}/catalogues/{Uri.EscapeDataString(productType)}/basic";
 
             try
             {

--- a/test/UKHO.ADDS.Clients.PermitService.Tests/Helpers/FakePermitHttpClientFactory.cs
+++ b/test/UKHO.ADDS.Clients.PermitService.Tests/Helpers/FakePermitHttpClientFactory.cs
@@ -1,0 +1,46 @@
+﻿using System.Net;
+using System.Text;
+using UKHO.ADDS.Infrastructure.Serialization.Json;
+
+namespace UKHO.ADDS.Clients.PermitService.Tests.Helpers
+{
+    public class FakePermitHttpClientFactory : DelegatingHandler, IHttpClientFactory
+    {
+        private readonly Func<HttpRequestMessage, (HttpStatusCode, object)> _httpMessageHandler;
+        private HttpClient _httpClient;
+
+        public FakePermitHttpClientFactory(Func<HttpRequestMessage, (HttpStatusCode, object)> httpMessageHandler) => _httpMessageHandler = httpMessageHandler;
+
+        public HttpClient HttpClient
+        {
+            get => _httpClient ?? CreateClient("");
+            private set => _httpClient = value;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            _httpClient = new HttpClient(this);
+            return HttpClient;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var (httpStatusCode, responseValue) = _httpMessageHandler(request);
+            var response = new HttpResponseMessage { StatusCode = httpStatusCode };
+
+            switch (responseValue)
+            {
+                case null:
+                    break;
+                case Stream stream:
+                    response.Content = new StreamContent(stream);
+                    break;
+                default:
+                    response.Content = new StringContent(JsonCodec.Encode(responseValue), Encoding.UTF8, "application/json");
+                    break;
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/UKHO.ADDS.Clients.PermitService.Tests/Helpers/FakePermitHttpClientFactory.cs
+++ b/test/UKHO.ADDS.Clients.PermitService.Tests/Helpers/FakePermitHttpClientFactory.cs
@@ -4,12 +4,9 @@ using UKHO.ADDS.Infrastructure.Serialization.Json;
 
 namespace UKHO.ADDS.Clients.PermitService.Tests.Helpers
 {
-    public class FakePermitHttpClientFactory : DelegatingHandler, IHttpClientFactory
+    public class FakePermitHttpClientFactory(Func<HttpRequestMessage, (HttpStatusCode, object)> httpMessageHandler) : DelegatingHandler, IHttpClientFactory
     {
-        private readonly Func<HttpRequestMessage, (HttpStatusCode, object)> _httpMessageHandler;
         private HttpClient _httpClient;
-
-        public FakePermitHttpClientFactory(Func<HttpRequestMessage, (HttpStatusCode, object)> httpMessageHandler) => _httpMessageHandler = httpMessageHandler;
 
         public HttpClient HttpClient
         {
@@ -25,7 +22,7 @@ namespace UKHO.ADDS.Clients.PermitService.Tests.Helpers
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var (httpStatusCode, responseValue) = _httpMessageHandler(request);
+            var (httpStatusCode, responseValue) = httpMessageHandler(request);
             var response = new HttpResponseMessage { StatusCode = httpStatusCode };
 
             switch (responseValue)

--- a/test/UKHO.ADDS.Clients.PermitService.Tests/PermitClientTests.cs
+++ b/test/UKHO.ADDS.Clients.PermitService.Tests/PermitClientTests.cs
@@ -14,8 +14,8 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
         private FakePermitHttpClientFactory _fakePermitHttpClientFactory;
         private PermitClient _permitApiClient;
         private Uri _lastRequestUri;
-        private ConcurrentQueue<object> _nextResponses;
-        private HttpStatusCode _nextResponseStatusCode;
+        private ConcurrentQueue<object> _responseBody;
+        private HttpStatusCode _responseStatusCode;
 
         [SetUp]
         public void Setup()
@@ -24,21 +24,21 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
             {
                 _lastRequestUri = request.RequestUri;
 
-                if (_nextResponses.IsEmpty)
+                if (_responseBody.IsEmpty)
                 {
-                    return (_nextResponseStatusCode, new object());
+                    return (_responseStatusCode, new object());
                 }
 
-                if (_nextResponses.TryDequeue(out var response))
+                if (_responseBody.TryDequeue(out var response))
                 {
-                    return (_nextResponseStatusCode, response);
+                    return (_responseStatusCode, response);
                 }
 
                 throw new Exception("Failed to dequeue next response");
             });
 
-            _nextResponses = new ConcurrentQueue<object>();
-            _nextResponseStatusCode = HttpStatusCode.OK;
+            _responseBody = new ConcurrentQueue<object>();
+            _responseStatusCode = HttpStatusCode.OK;
             _permitApiClient = new PermitClient(_fakePermitHttpClientFactory, @"https://permit-tests.net/", DUMMY_ACCESS_TOKEN);
         }
 
@@ -52,7 +52,7 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
             var apiVersion = "v1";
             var productType = "s100";
             var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(GetExpectedXmlString()));
-            _nextResponses.Enqueue(expectedStream);
+            _responseBody.Enqueue(expectedStream);
 
             var permitRequest = new PermitRequest
             {
@@ -72,11 +72,11 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
                 UserPermits = new List<UserPermit>
                 {
                     new() {
-                        Title = "IHO Test System",
+                        Title = "UPN1",
                         Upn = "869D4E0E902FA2E1B934A3685E5D0E85C1FDEC8BD4E5F6"
                     },
                     new() {
-                        Title = "OeM Test 1",
+                        Title = "UPN2",
                         Upn = "7B5CED73389DECDB110E6E803F957253F0DE13D1G7H8I9"
                     }
                 }
@@ -119,19 +119,19 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
                 UserPermits = new List<UserPermit>
                 {
                     new() {
-                        Title = "IHO Test System",
+                        Title = "UPN1",
                         Upn = "869D4E0E902FA2E1B934A3685E5D0E85C1FDEC8BD4E5F6"
                     },
                     new() {
-                        Title = "OeM Test 1",
+                        Title = "UPN2",
                         Upn = "7B5CED73389DECDB110E6E803F957253F0DE13D1G7H8I9"
                     }
                 }
             };
 
             var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(GetExpectedXmlString()));
-            _nextResponses.Enqueue(expectedStream);
-            _nextResponseStatusCode = HttpStatusCode.BadRequest;
+            _responseBody.Enqueue(expectedStream);
+            _responseStatusCode = HttpStatusCode.BadRequest;
 
             var result = await _permitApiClient.GetPermitAsync(apiVersion, productType, permitRequest, correlationId);
 
@@ -168,18 +168,18 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
                 UserPermits = new List<UserPermit>
                 {
                     new() {
-                        Title = "IHO Test System",
+                        Title = "UPN1",
                         Upn = "869D4E0E902FA2E1B934A3685E5D0E85C1FDEC8BD4E5F6"
                     },
                     new() {
-                        Title = "OeM Test 1",
+                        Title = "UPN2",
                         Upn = "7B5CED73389DECDB110E6E803F957253F0DE13D1G7H8I9"
                     }
                 }
             };
 
             var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(GetExpectedXmlString()));
-            _nextResponses.Enqueue(expectedStream);
+            _responseBody.Enqueue(expectedStream);
 
             var result = await _permitApiClient.GetPermitAsync(apiVersion, productType, permitRequest, correlationId);
 

--- a/test/UKHO.ADDS.Clients.PermitService.Tests/PermitClientTests.cs
+++ b/test/UKHO.ADDS.Clients.PermitService.Tests/PermitClientTests.cs
@@ -1,0 +1,207 @@
+﻿using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using NUnit.Framework;
+using UKHO.ADDS.Clients.PermitService.Models;
+using UKHO.ADDS.Clients.PermitService.Tests.Helpers;
+
+namespace UKHO.ADDS.Clients.PermitService.Tests
+{
+    public class PermitClientTests
+    {
+        private const string DUMMY_ACCESS_TOKEN = "ACarefullyEncodedSecretAccessToken";
+        private const string XCorrelationIdHeaderKey = "X-Correlation-ID";
+        private FakePermitHttpClientFactory _fakePermitHttpClientFactory;
+        private PermitClient _permitApiClient;
+        private Uri _lastRequestUri;
+        private ConcurrentQueue<object> _nextResponses;
+        private HttpStatusCode _nextResponseStatusCode;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fakePermitHttpClientFactory = new FakePermitHttpClientFactory(request =>
+            {
+                _lastRequestUri = request.RequestUri;
+
+                if (_nextResponses.IsEmpty)
+                {
+                    return (_nextResponseStatusCode, new object());
+                }
+
+                if (_nextResponses.TryDequeue(out var response))
+                {
+                    return (_nextResponseStatusCode, response);
+                }
+
+                throw new Exception("Failed to dequeue next response");
+            });
+
+            _nextResponses = new ConcurrentQueue<object>();
+            _nextResponseStatusCode = HttpStatusCode.OK;
+            _permitApiClient = new PermitClient(_fakePermitHttpClientFactory, @"https://permit-tests.net/", DUMMY_ACCESS_TOKEN);
+        }
+
+        [TearDown]
+        public void TearDown() => _fakePermitHttpClientFactory.Dispose();
+
+        [Test]
+        public async Task GetPermitAsync_Success_ReturnsSuccessResult()
+        {
+            var correlationId = Guid.NewGuid().ToString();
+            var apiVersion = "v1";
+            var productType = "s100";
+            var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(GetExpectedXmlString()));
+            _nextResponses.Enqueue(expectedStream);
+
+            var permitRequest = new PermitRequest
+            {
+                Products = new List<Product>
+                {
+                    new() {
+                        ProductName = "Product1",
+                        EditionNumber = 1,
+                        PermitExpiryDate = DateTime.UtcNow.AddDays(1).ToString("YYYY-MM-DD")
+                    },
+                    new() {
+                        ProductName = "Product2",
+                        EditionNumber = 2,
+                        PermitExpiryDate = DateTime.UtcNow.AddDays(1).ToString("YYYY-MM-DD")
+                    }
+                },
+                UserPermits = new List<UserPermit>
+                {
+                    new() {
+                        Title = "IHO Test System",
+                        Upn = "869D4E0E902FA2E1B934A3685E5D0E85C1FDEC8BD4E5F6"
+                    },
+                    new() {
+                        Title = "OeM Test 1",
+                        Upn = "7B5CED73389DECDB110E6E803F957253F0DE13D1G7H8I9"
+                    }
+                }
+            };
+
+            var result = await _permitApiClient.GetPermitAsync(apiVersion, productType, permitRequest, correlationId);
+
+            var isSuccess = result.IsSuccess(out var permitResponse);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(isSuccess, Is.True);
+                Assert.That(permitResponse, Is.Not.Null);
+                Assert.That(permitResponse, Is.EqualTo(expectedStream));
+                Assert.That(_lastRequestUri?.AbsolutePath, Is.EqualTo($"/v1/permits/s100"));
+            });
+        }
+
+        [Test]
+        public async Task GetPermitAsync_Failure_ReturnsFailureResult()
+        {
+            var correlationId = Guid.NewGuid().ToString();
+            var apiVersion = "v1";
+            var productType = "s100";
+            var permitRequest = new PermitRequest
+            {
+                Products = new List<Product>
+                {
+                    new() {
+                        ProductName = "Product1",
+                        EditionNumber = 1,
+                        PermitExpiryDate = DateTime.UtcNow.AddDays(1).ToString("YYYY-MM-DD")
+                    },
+                    new() {
+                        ProductName = "Product2",
+                        EditionNumber = 2,
+                        PermitExpiryDate = DateTime.UtcNow.AddDays(1).ToString("YYYY-MM-DD")
+                    }
+                },
+                UserPermits = new List<UserPermit>
+                {
+                    new() {
+                        Title = "IHO Test System",
+                        Upn = "869D4E0E902FA2E1B934A3685E5D0E85C1FDEC8BD4E5F6"
+                    },
+                    new() {
+                        Title = "OeM Test 1",
+                        Upn = "7B5CED73389DECDB110E6E803F957253F0DE13D1G7H8I9"
+                    }
+                }
+            };
+
+            var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(GetExpectedXmlString()));
+            _nextResponses.Enqueue(expectedStream);
+            _nextResponseStatusCode = HttpStatusCode.BadRequest;
+
+            var result = await _permitApiClient.GetPermitAsync(apiVersion, productType, permitRequest, correlationId);
+
+            var isSuccess = result.IsSuccess(out var value, out var error);
+            Assert.Multiple(() =>
+            {
+                Assert.That(isSuccess, Is.False);
+                Assert.That(value, Is.Null);
+                Assert.That(error, Is.Not.Null);
+            });
+        }
+
+        [Test]
+        public async Task TestGetPermitAsyncSetsRequestHeader()
+        {
+            var correlationId = Guid.NewGuid().ToString();
+            var apiVersion = "v1";
+            var productType = "s100";
+            var permitRequest = new PermitRequest
+            {
+                Products = new List<Product>
+                {
+                    new() {
+                        ProductName = "Product1",
+                        EditionNumber = 1,
+                        PermitExpiryDate = DateTime.UtcNow.AddDays(1).ToString("YYYY-MM-DD")
+                    },
+                    new() {
+                        ProductName = "Product2",
+                        EditionNumber = 2,
+                        PermitExpiryDate = DateTime.UtcNow.AddDays(1).ToString("YYYY-MM-DD")
+                    }
+                },
+                UserPermits = new List<UserPermit>
+                {
+                    new() {
+                        Title = "IHO Test System",
+                        Upn = "869D4E0E902FA2E1B934A3685E5D0E85C1FDEC8BD4E5F6"
+                    },
+                    new() {
+                        Title = "OeM Test 1",
+                        Upn = "7B5CED73389DECDB110E6E803F957253F0DE13D1G7H8I9"
+                    }
+                }
+            };
+
+            var expectedStream = new MemoryStream(Encoding.UTF8.GetBytes(GetExpectedXmlString()));
+            _nextResponses.Enqueue(expectedStream);
+
+            var result = await _permitApiClient.GetPermitAsync(apiVersion, productType, permitRequest, correlationId);
+
+            Assert.That(_fakePermitHttpClientFactory.HttpClient.DefaultRequestHeaders.Authorization, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_fakePermitHttpClientFactory.HttpClient.DefaultRequestHeaders.Authorization.Scheme, Is.EqualTo("bearer"));
+                Assert.That(_fakePermitHttpClientFactory.HttpClient.DefaultRequestHeaders.Authorization.Parameter, Is.EqualTo(DUMMY_ACCESS_TOKEN));
+                Assert.That(_fakePermitHttpClientFactory.HttpClient.DefaultRequestHeaders.GetValues(XCorrelationIdHeaderKey).FirstOrDefault(), Is.EqualTo(correlationId));
+            });
+        }
+
+
+        private static string GetExpectedXmlString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("<?xmlversion=\"1.0\"encoding=\"UTF-8\"standalone=\"yes\"?><Permitxmlns:S100SE=\"http://www.iho.int/s100/se/5.2\"xmlns:ns2=\"http://standards.iso.org/iso/19115/-3/gco/1.0\"xmlns=\"http://www.iho.int/s100/se/5.2\"><S100SE:header>");
+            sb.Append("<S100SE:issueDate>2024-09-02+01:00</S100SE:issueDate><S100SE:dataServerName>fakeDataServerName</S100SE:dataServerName><S100SE:dataServerIdentifier>fakeDataServerIdentifier</S100SE:dataServerIdentifier><S100SE:version>1</S100SE:version>");
+            sb.Append("<S100SE:userpermit>fakeUserPermit</S100SE:userpermit></S100SE:header><S100SE:products><S100SE:productid=\"fakeID\"><S100SE:datasetPermit><S100SE:filename>fakefilename</S100SE:filename><S100SE:editionNumber>1</S100SE:editionNumber>");
+            sb.Append("<S100SE:issueDate>2024-09-02+01:00</S100SE:issueDate><S100SE:expiry>2024-09-02</S100SE:expiry><S100SE:encryptedKey>fakeencryptedkey</S100SE:encryptedKey></S100SE:datasetPermit></S100SE:product></S100SE:products></Permit>");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/test/UKHO.ADDS.Clients.PermitService.Tests/PermitClientTests.cs
+++ b/test/UKHO.ADDS.Clients.PermitService.Tests/PermitClientTests.cs
@@ -12,8 +12,7 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
         private const string DUMMY_ACCESS_TOKEN = "ACarefullyEncodedSecretAccessToken";
         private const string XCorrelationIdHeaderKey = "X-Correlation-ID";
         private FakePermitHttpClientFactory _fakePermitHttpClientFactory;
-        private PermitClient _permitApiClient;
-        private Uri _lastRequestUri;
+        private PermitClient _permitApiClient;        
         private ConcurrentQueue<object> _responseBody;
         private HttpStatusCode _responseStatusCode;
 
@@ -22,8 +21,6 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
         {
             _fakePermitHttpClientFactory = new FakePermitHttpClientFactory(request =>
             {
-                _lastRequestUri = request.RequestUri;
-
                 if (_responseBody.IsEmpty)
                 {
                     return (_responseStatusCode, new object());
@@ -90,8 +87,7 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
             {
                 Assert.That(isSuccess, Is.True);
                 Assert.That(permitResponse, Is.Not.Null);
-                Assert.That(permitResponse, Is.EqualTo(expectedStream));
-                Assert.That(_lastRequestUri?.AbsolutePath, Is.EqualTo($"/v1/permits/s100"));
+                Assert.That(permitResponse, Is.EqualTo(expectedStream));                
             });
         }
 
@@ -191,8 +187,6 @@ namespace UKHO.ADDS.Clients.PermitService.Tests
                 Assert.That(_fakePermitHttpClientFactory.HttpClient.DefaultRequestHeaders.GetValues(XCorrelationIdHeaderKey).FirstOrDefault(), Is.EqualTo(correlationId));
             });
         }
-
-
         private static string GetExpectedXmlString()
         {
             var sb = new StringBuilder();

--- a/test/UKHO.ADDS.Clients.PermitService.Tests/UKHO.ADDS.Clients.PermitService.Tests.csproj
+++ b/test/UKHO.ADDS.Clients.PermitService.Tests/UKHO.ADDS.Clients.PermitService.Tests.csproj
@@ -7,6 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\UKHO.ADDS.Clients.PermitService\UKHO.ADDS.Clients.PermitService.csproj" />
   </ItemGroup>
 

--- a/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/Helpers/FakeScsHttpClientFactory.cs
+++ b/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/Helpers/FakeScsHttpClientFactory.cs
@@ -1,0 +1,46 @@
+﻿using System.Net;
+using System.Text;
+using UKHO.ADDS.Infrastructure.Serialization.Json;
+
+namespace UKHO.ADDS.Clients.SalesCatalogueService.Tests.Helpers
+{
+    public class FakeScsHttpClientFactory : DelegatingHandler, IHttpClientFactory
+    {
+        private readonly Func<HttpRequestMessage, (HttpStatusCode, object)> _httpMessageHandler;
+        private HttpClient _httpClient;
+
+        public FakeScsHttpClientFactory(Func<HttpRequestMessage, (HttpStatusCode, object)> httpMessageHandler) => _httpMessageHandler = httpMessageHandler;
+
+        public HttpClient HttpClient
+        {
+            get => _httpClient ?? CreateClient("");
+            private set => _httpClient = value;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            _httpClient = new HttpClient(this);
+            return HttpClient;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var (httpStatusCode, responseValue) = _httpMessageHandler(request);
+            var response = new HttpResponseMessage { StatusCode = httpStatusCode };
+
+            switch (responseValue)
+            {
+                case null:
+                    break;
+                case Stream stream:
+                    response.Content = new StreamContent(stream);
+                    break;
+                default:
+                    response.Content = new StringContent(JsonCodec.Encode(responseValue), Encoding.UTF8, "application/json");
+                    break;
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/SalesCatalogueClientTest.cs
+++ b/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/SalesCatalogueClientTest.cs
@@ -11,8 +11,7 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService.Tests
     {
         private const string DUMMY_ACCESS_TOKEN = "ACarefullyEncodedSecretAccessToken";
         private FakeScsHttpClientFactory _fakeScsHttpClientFactory;
-        private SalesCatalogueClient _salesCatalogueApiClient;
-        private Uri _lastRequestUri;
+        private SalesCatalogueClient _salesCatalogueApiClient;        
         private object _responseBody;
         private DateTime _responseHeader;
         private HttpStatusCode _responseStatusCode;
@@ -21,8 +20,7 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService.Tests
         public void Setup()
         {
             _fakeScsHttpClientFactory = new FakeScsHttpClientFactory(request =>
-            {
-                _lastRequestUri = request.RequestUri;
+            {                
                 return (_responseStatusCode, _responseBody, _responseHeader);
             });
 
@@ -39,18 +37,7 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService.Tests
             {
                 disposableResponse.Dispose();
             }
-        }
-        private static void CheckResponseMatchesExpectedResponse(S100SalesCatalogueResponse? expectedResponse, IResult<S100SalesCatalogueResponse> response)
-        {
-            var isSuccess = response.IsSuccess(out var responseValue);
-
-            Assert.That(responseValue!.ResponseBody.Count, Is.EqualTo(expectedResponse!.ResponseBody.Count));
-            Assert.Multiple(() =>
-            {
-                Assert.That(responseValue.ResponseCode, Is.EqualTo(expectedResponse.ResponseCode));
-                Assert.That(responseValue.LastModified, Is.EqualTo(expectedResponse.LastModified));
-            });
-        }
+        }       
 
         [Test]
         public async Task GetS100ProductsFromSpecificDateAsync_Success_ReturnsSuccessResult()
@@ -152,6 +139,17 @@ namespace UKHO.ADDS.Clients.SalesCatalogueService.Tests
             {
                 Assert.That(httpClient.DefaultRequestHeaders.Contains(ApiHeaderKeys.XCorrelationIdHeaderKey), Is.True);
                 Assert.That(httpClient.DefaultRequestHeaders.GetValues(ApiHeaderKeys.XCorrelationIdHeaderKey).FirstOrDefault(), Is.EqualTo(correlationId));
+            });
+        }
+        private static void CheckResponseMatchesExpectedResponse(S100SalesCatalogueResponse? expectedResponse, IResult<S100SalesCatalogueResponse> response)
+        {
+            var isSuccess = response.IsSuccess(out var responseValue);
+
+            Assert.That(responseValue!.ResponseBody.Count, Is.EqualTo(expectedResponse!.ResponseBody.Count));
+            Assert.Multiple(() =>
+            {
+                Assert.That(responseValue.ResponseCode, Is.EqualTo(expectedResponse.ResponseCode));
+                Assert.That(responseValue.LastModified, Is.EqualTo(expectedResponse.LastModified));
             });
         }
     }

--- a/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/SalesCatalogueClientTest.cs
+++ b/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/SalesCatalogueClientTest.cs
@@ -1,0 +1,130 @@
+﻿using System.Net;
+using NUnit.Framework;
+using UKHO.ADDS.Clients.Common.Constants;
+using UKHO.ADDS.Clients.SalesCatalogueService.Models;
+using UKHO.ADDS.Clients.SalesCatalogueService.Tests.Helpers;
+using UKHO.ADDS.Infrastructure.Results;
+
+namespace UKHO.ADDS.Clients.SalesCatalogueService.Tests
+{
+    public class SalesCatalogueClientTests
+    {
+        private const string DUMMY_ACCESS_TOKEN = "ACarefullyEncodedSecretAccessToken";
+        private FakeScsHttpClientFactory _fakeScsHttpClientFactory;
+        private SalesCatalogueClient _salesCatalogueApiClient;
+        private Uri _lastRequestUri;
+        private HttpContent _nextResponse;
+        private HttpStatusCode _nextResponseStatusCode;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fakeScsHttpClientFactory = new FakeScsHttpClientFactory(request =>
+            {
+                _lastRequestUri = request.RequestUri;
+                return (_nextResponseStatusCode, _nextResponse);
+            });
+
+            _nextResponse = new StringContent(string.Empty);
+            _nextResponseStatusCode = HttpStatusCode.OK;
+            _salesCatalogueApiClient = new SalesCatalogueClient(_fakeScsHttpClientFactory, @"https://fss-tests.net/basePath/", DUMMY_ACCESS_TOKEN);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _fakeScsHttpClientFactory.Dispose();
+            _nextResponse?.Dispose();
+        }
+        private static void CheckResponseMatchesExpectedResponse(S100SalesCatalogueResponse expectedResponse, IResult<S100SalesCatalogueResponse> response)
+        {
+            var isSuccess = response.IsSuccess(out var responseValue);
+
+            Assert.That(responseValue.ResponseBody, Is.EqualTo(expectedResponse.ResponseBody));
+            Assert.Multiple(() =>
+            {
+                Assert.That(responseValue.ResponseCode, Is.EqualTo(expectedResponse.ResponseCode));
+                Assert.That(responseValue.LastModified, Is.EqualTo(expectedResponse.LastModified));
+            });
+        }
+
+        //[Test]
+        //public async Task GetS100ProductsFromSpecificDateAsync_Success_ReturnsSuccessResult()
+        //{
+        //    // Arrange
+        //    var expectedProducts = new List<S100Products>
+        //    {
+        //        new S100Products { ProductName = "Product1", LatestEditionNumber = 1, LatestUpdateNumber = 1 },
+        //        new S100Products { ProductName = "Product2", LatestEditionNumber = 2, LatestUpdateNumber = 2 }
+        //    };
+        //    var expectedResponse = new S100SalesCatalogueResponse
+        //    {
+        //        ResponseBody = expectedProducts,
+        //        ResponseCode = HttpStatusCode.OK,
+        //        LastModified = DateTime.UtcNow
+        //    };
+        //    var correlationId = Guid.NewGuid().ToString();
+        //    var apiVersion = "v2";
+        //    var productType = "s100";
+        //    var sinceDateTime = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+        //    _nextResponse = new StringContent(JsonSerializer.Serialize(expectedResponse), Encoding.UTF8, "application/json");
+        //    _nextResponseStatusCode = HttpStatusCode.OK;
+
+        //    // Act
+        //    var result = await _salesCatalogueApiClient.GetS100ProductsFromSpecificDateAsync(apiVersion, productType, sinceDateTime, correlationId);
+
+        //    // Assert
+        //    CheckResponseMatchesExpectedResponse(expectedResponse, result);
+        //}
+
+        [Test]
+        public async Task GetS100ProductsFromSpecificDateAsync_Failure_ReturnsFailureResult()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            var apiVersion = "v1";
+            var productType = "s100";
+            var sinceDateTime = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+            _nextResponse = new StringContent("Error message");
+            _nextResponseStatusCode = HttpStatusCode.BadRequest;
+
+            // Act
+            var result = await _salesCatalogueApiClient.GetS100ProductsFromSpecificDateAsync(apiVersion, productType, sinceDateTime, correlationId);
+
+            // Assert
+            var isSuccess = result.IsSuccess(out var value, out var error);
+            Assert.Multiple(() =>
+            {
+                Assert.That(isSuccess, Is.False);
+                Assert.That(value, Is.Null);
+                Assert.That(error, Is.Not.Null);
+            });
+        }
+
+        [Test]
+        public async Task GetS100ProductsFromSpecificDateAsync_SetsCorrelationIdHeader()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            var apiVersion = "v1";
+            var productType = "s100";
+            var sinceDateTime = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+            _nextResponse = new StringContent("Response content");
+            _nextResponseStatusCode = HttpStatusCode.OK;
+
+            // Act
+            await _salesCatalogueApiClient.GetS100ProductsFromSpecificDateAsync(apiVersion, productType, sinceDateTime, correlationId);
+
+            // Assert
+            var httpClient = _fakeScsHttpClientFactory.HttpClient;
+            Assert.Multiple(() =>
+            {
+                Assert.That(httpClient.DefaultRequestHeaders.Contains(ApiHeaderKeys.XCorrelationIdHeaderKey), Is.True);
+                Assert.That(httpClient.DefaultRequestHeaders.GetValues(ApiHeaderKeys.XCorrelationIdHeaderKey).FirstOrDefault(), Is.EqualTo(correlationId));
+            });
+        }
+    }
+}

--- a/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/UKHO.ADDS.Clients.SalesCatalogueService.Tests.csproj
+++ b/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/UKHO.ADDS.Clients.SalesCatalogueService.Tests.csproj
@@ -15,6 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="UKHO.ADDS.Infrastructure.Serialization" Version="0.0.50322-alpha.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/UKHO.ADDS.Clients.SalesCatalogueService.Tests.csproj
+++ b/test/UKHO.ADDS.Clients.SalesCatalogueService.Tests/UKHO.ADDS.Clients.SalesCatalogueService.Tests.csproj
@@ -7,6 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\UKHO.ADDS.Clients.SalesCatalogueService\UKHO.ADDS.Clients.SalesCatalogueService.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR contains clients addition for SCS (Get S100 Catalogue Endpoint) and Permit Service Endpoints in the NuGet solution,
so that these services can be reused across different projects and provide centralized, consistent access to the endpoints.
