### PR TITLE
214780 - new overloads for batch creation methods 

### DIFF
--- a/src/UKHO.ADDS.Clients.Common/Extensions/HttpResponseMessageExtensions.cs
+++ b/src/UKHO.ADDS.Clients.Common/Extensions/HttpResponseMessageExtensions.cs
@@ -51,7 +51,7 @@ namespace UKHO.ADDS.Clients.Common.Extensions
             }
         }
 
-        public static async Task<IResult<TValue>> CreateResultAsync<TValue>(this HttpResponseMessage response, string applicationName,string correlationId) where TValue : class
+        public static async Task<IResult<TValue>> CreateResultAsync<TValue>(this HttpResponseMessage response, string applicationName, string correlationId) where TValue : class
         {
             try
             {
@@ -114,7 +114,7 @@ namespace UKHO.ADDS.Clients.Common.Extensions
             }
         }
 
-        public static async Task<IDictionary<string, object>> CreateErrorMetadata(this HttpResponseMessage response, string applicationName, string correlationId)
+        public static async Task<IDictionary<string, object>> CreateErrorMetadata(this HttpResponseMessage response, string applicationName, string? correlationId = null)
         {
             IDictionary<string, object> errorMetadata = ErrorFactory.CreateProperties(correlationId);
 

--- a/src/UKHO.ADDS.Clients.FileShareService.ReadWrite/FileShareReadWriteClient.cs
+++ b/src/UKHO.ADDS.Clients.FileShareService.ReadWrite/FileShareReadWriteClient.cs
@@ -45,7 +45,17 @@ namespace UKHO.ADDS.Clients.FileShareService.ReadWrite
 
         public Task<IResult<AppendAclResponse>> AppendAclAsync(string batchId, Acl acl, CancellationToken cancellationToken = default) => Task.FromResult<IResult<AppendAclResponse>>(Result.Success(new AppendAclResponse()));
 
+        public async Task<IResult<IBatchHandle>> CreateBatchAsync(BatchModel batchModel, CancellationToken cancellationToken = default)
+        {
+            return await CreateBatchInternalAsync(batchModel, cancellationToken);
+        }
+
         public async Task<IResult<IBatchHandle>> CreateBatchAsync(BatchModel batchModel, string correlationId, CancellationToken cancellationToken = default)
+        {
+            return await CreateBatchInternalAsync(batchModel, cancellationToken, correlationId);
+        }
+
+        private async Task<IResult<IBatchHandle>> CreateBatchInternalAsync(BatchModel batchModel, CancellationToken cancellationToken, string? correlationId = null)
         {
             var uri = new Uri("batch", UriKind.Relative);
 
@@ -103,11 +113,14 @@ namespace UKHO.ADDS.Clients.FileShareService.ReadWrite
             };
         }
 
-        protected async Task<HttpClient> CreateHttpClientWithHeadersAsync(string correlationId)
+        protected async Task<HttpClient> CreateHttpClientWithHeadersAsync(string? correlationId = null)
         {
             var httpClient = _httpClientFactory.CreateClient();
             await httpClient.SetAuthenticationHeaderAsync(_authTokenProvider);
-            httpClient.SetCorrelationIdHeader(correlationId);
+            if (!string.IsNullOrEmpty(correlationId))
+            {
+                httpClient.SetCorrelationIdHeader(correlationId);
+            }
             return httpClient;
         }
     }

--- a/src/UKHO.ADDS.Clients.FileShareService.ReadWrite/IFileShareReadWriteClient.cs
+++ b/src/UKHO.ADDS.Clients.FileShareService.ReadWrite/IFileShareReadWriteClient.cs
@@ -9,7 +9,11 @@ namespace UKHO.ADDS.Clients.FileShareService.ReadWrite
     public interface IFileShareReadWriteClient : IFileShareReadOnlyClient
     {
         Task<IResult<AppendAclResponse>> AppendAclAsync(string batchId, Acl acl, CancellationToken cancellationToken = default);
+
+        Task<IResult<IBatchHandle>> CreateBatchAsync(BatchModel batchModel, CancellationToken cancellationToken = default);
+
         Task<IResult<IBatchHandle>> CreateBatchAsync(BatchModel batchModel, string correlationId, CancellationToken cancellationToken = default);
+
         Task<IResult<BatchStatusResponse>> GetBatchStatusAsync(IBatchHandle batchHandle);
 
         Task<IResult> AddFileToBatchAsync(IBatchHandle batchHandle, Stream stream, string fileName, string mimeType,


### PR DESCRIPTION
#### PR Summary
This pull request introduces new overloads for batch creation methods to include an optional correlation ID.
- `HttpResponseMessageExtensions.cs`: Added `correlationId` parameter to `CreateResultAsync` and `CreateErrorMetadata` methods.
- `FileShareReadWriteClient.cs`: Introduced two overloads of `CreateBatchAsync` and a private method `CreateBatchInternalAsync` for batch processing.
- `IFileShareReadWriteClient.cs`: Updated interface to include new overloads of `CreateBatchAsync`.
- `CreateBatchTest.cs`: Added tests for new batch creation methods with and without correlation ID, and updated assertions for header checks.
