### PR TITLE
Enhance README with authentication provider examples and update Kiota…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,29 @@ This library provides extension methods to simplify the registration and configu
 Register the default Kiota handlers, client factory, and your authentication provider:
 
    ```sh
-   services.RegisterKiotaClient<MyKiotaClient>( "MyApi:Endpoint", new Dictionary<string, string> { { "Authorization", "Bearer my-token" }, { "Custom-Header", "Value" } } );
+   services.AddKiotaDefaults(new T()); where T implemented IAuthenticationProvider
+   ```
+
+There are some standard AuthenticationProviders that can be used out of the box:
+
+- When no authentication is required (interacting with mock services): AnonymousAuthenticationProvider
+    
+    ```sh
+    services.AddKiotaDefaults(new AnonymousAuthenticationProvider());
+    ```
+
+- For Authentication with Azure:  AzureIdentityAuthenticationProvider
+- 
+    ```sh
+    services.AddKiotaDefaults(new AzureIdentityAuthenticationProvider(new DefaultAzureCredential()));
+    ```
+
+### 2. Register Kiota Client
+
+Register the kiota client which will work with the previous defaults that have been registered:
+
+   ```sh
+   services.RegisterKiotaClient<MyKiotaClient>( "MyApi:Endpoint", new Dictionary<string, string> { { "Custom-Header", "Value" } } );
    ```
 
 - `"MyApi:Endpoint"` is the configuration key for the API base URL.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ There are some standard AuthenticationProviders that can be used out of the box:
     ```
 
 - For Authentication with Azure:  AzureIdentityAuthenticationProvider
-- 
+ 
     ```sh
     services.AddKiotaDefaults(new AzureIdentityAuthenticationProvider(new DefaultAzureCredential()));
     ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,22 +101,6 @@ stages:
         workingDirectory: '$(Build.SourcesDirectory)'
 
     - template: deployment/KiotaClientGeneration.yml
-
-    - task: PowerShell@2
-      displayName: List all .cs files included in UKHO.ADDS.Clients.SalesCatalogueService.csproj
-      inputs:
-        targetType: inline
-        script: |
-          $csproj = Get-ChildItem -Path "$(Build.SourcesDirectory)" -Recurse -Filter UKHO.ADDS.Clients.SalesCatalogueService.csproj | Select-Object -First 1
-          if ($csproj) {
-            $projDir = Split-Path $csproj.FullName
-            Write-Host "Listing all .cs files under $projDir (excluding bin/obj):"
-            Get-ChildItem -Path $projDir -Recurse -Include *.cs -File | Where-Object {
-              $_.FullName -notmatch '\\bin\\' -and $_.FullName -notmatch '\\obj\\'
-            } | ForEach-Object { Write-Host $_.FullName }
-          } else {
-            Write-Host "No UKHO.ADDS.Clients.SalesCatalogueService.csproj found."
-          }
     
     - task: DotNetCoreCLI@2
       displayName: Pack libraries


### PR DESCRIPTION
This pull request introduces updates to the documentation and streamlines the CI pipeline configuration. The key changes include enhancing the `README.md` with examples of authentication providers and simplifying the Azure Pipelines script by removing an inline PowerShell task.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R71): Added examples of standard `AuthenticationProviders` (e.g., `AnonymousAuthenticationProvider`, `AzureIdentityAuthenticationProvider`) and updated instructions for registering Kiota defaults and clients. This improves clarity and usability for developers implementing Kiota clients.

### CI Pipeline Simplification:

* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L105-L120): Removed an inline PowerShell task that listed `.cs` files in a specific project. This reduces redundancy and simplifies the pipeline configuration.