### PR TITLE
Refactor ClientFactory to use default authentication

### DIFF
--- a/src/UKHO.ADDS.Clients.Common/MiddlewareExtensions/ClientFactory.cs
+++ b/src/UKHO.ADDS.Clients.Common/MiddlewareExtensions/ClientFactory.cs
@@ -10,8 +10,6 @@ namespace UKHO.ADDS.Clients.Common.MiddlewareExtensions
         IHttpClientFactory httpClientFactory,
         ILogger<ClientFactory> logger)
     {
-        private readonly IAuthenticationProvider _defaultAuthProvider = defaultAuthProvider;
-
         /// <summary>
         /// Creates an instance of the specified Kiota client type using the provided authentication provider and an HttpClient
         /// obtained from the IHttpClientFactory. The client type must have a constructor that accepts an IRequestAdapter.
@@ -21,7 +19,7 @@ namespace UKHO.ADDS.Clients.Common.MiddlewareExtensions
         /// <exception cref="InvalidOperationException">
         /// Thrown if the client type does not have a constructor accepting an IRequestAdapter.
         /// </exception>
-        public TClient GetClient<TClient>(IAuthenticationProvider? authenticationProvider = null) where TClient : class
+        public TClient GetClient<TClient>() where TClient : class
         {
             // Find a constructor that takes IRequestAdapter
             var ctor = typeof(TClient).GetConstructor([typeof(IRequestAdapter)]);
@@ -30,17 +28,10 @@ namespace UKHO.ADDS.Clients.Common.MiddlewareExtensions
                 throw new InvalidOperationException($"{typeof(TClient).Name} must have a constructor with IRequestAdapter parameter.");
             }
 
-            // If an authenitcationProvider is specified then use it, otherwise use the registered authentication provider in the Service Provider
-            var provider = authenticationProvider ?? _defaultAuthProvider;
-            if (provider == null)
-            {
-                throw new InvalidOperationException($"{typeof(TClient).Name} must have an Authentication Provider registered.");
-            }
-
             // Create the Http client here to make sure it is configured correctly
             var httpClient = httpClientFactory.CreateClient(typeof(TClient).Name);
             logger.LogInformation("Creating client for {ClientType} with base address: {baseAddress}", typeof(TClient).Name, httpClient.BaseAddress);
-            return (TClient)ctor.Invoke([new HttpClientRequestAdapter(provider, httpClient: httpClient)]);
+            return (TClient)ctor.Invoke([new HttpClientRequestAdapter(defaultAuthProvider, httpClient: httpClient)]);
         }
     }
 }

--- a/src/UKHO.ADDS.Clients.Common/MiddlewareExtensions/KiotaMiddlewareExtensions.cs
+++ b/src/UKHO.ADDS.Clients.Common/MiddlewareExtensions/KiotaMiddlewareExtensions.cs
@@ -31,19 +31,17 @@ namespace UKHO.ADDS.Clients.Common.MiddlewareExtensions
         /// <param name="services">The service collection to register the client with.</param>
         /// <param name="endpointConfigKey">The configuration key for the endpoint URL.</param>
         /// <param name="headers">Optional default headers to add to the HTTP client.</param>
-        /// <param name="authenticationProvider">Optional authentication provider to use for the client.</param>"
         public static void RegisterKiotaClient<TClient>(
             this IServiceCollection services,
             string endpointConfigKey,
-            IDictionary<string, string>? headers = null,
-            IAuthenticationProvider? authenticationProvider = null)
+            IDictionary<string, string>? headers = null)
             where TClient : class
         {
             // Ensure Inspection Handler is configured to inspect response headers
             var headersOption = new HeadersInspectionHandlerOption { InspectResponseHeaders = true };
             services.AddSingleton(headersOption);
             services.AddConfiguredHttpClient<TClient>(endpointConfigKey, headers);
-            services.AddSingleton(sp => sp.GetRequiredService<ClientFactory>().GetClient<TClient>(authenticationProvider));
+            services.AddSingleton(sp => sp.GetRequiredService<ClientFactory>().GetClient<TClient>());
         }
 
         /// <summary>


### PR DESCRIPTION
Removed optional IAuthenticationProvider from GetClient<TClient> method in ClientFactory. The method now utilizes a default authentication provider set during instantiation. Updated RegisterKiotaClient to eliminate the optional authenticationProvider parameter, simplifying client registration.