### PR TITLE
UpdateMiddleware and add local copies of openapi spec to pipeline for…

### DIFF
--- a/deployment/KiotaClientGeneration.yml
+++ b/deployment/KiotaClientGeneration.yml
@@ -2,7 +2,7 @@ steps:
   - template: KiotaGenerateClients.yml
     parameters:
       openApiRepo: 'openApiSpecSalesCatalogueServiceSharedAssets'
-      openApiSpecPath: 'salesCatalogue_ExchangeSetService_API_definition_v1.10.yaml'
+      openApiSpecPath: '**/salesCatalogue_ExchangeSetService_API_definition_v1.10.yaml'
       outputDirectory: '$(Build.SourcesDirectory)\src\UKHO.ADDS.Clients.SalesCatalogueService\GeneratedClient'
       language: 'csharp'
       GeneratedApiClassName: 'KiotaSalesCatalogueService'
@@ -11,7 +11,7 @@ steps:
   - template: KiotaGenerateClients.yml
     parameters:
       openApiRepo: 'openApiSpecFileShareService'
-      openApiSpecPath: 'file-share-service.openApi-public.yaml'
+      openApiSpecPath: '**/file-share-service.openApi-public.yaml'
       outputDirectory: '$(Build.SourcesDirectory)\src\UKHO.ADDS.Clients.FileShareService.ReadOnly\GeneratedClient'
       language: 'csharp'
       GeneratedApiClassName: 'KiotaFileShareServiceReadOnly'
@@ -20,7 +20,7 @@ steps:
   - template: KiotaGenerateClients.yml
     parameters:
       openApiRepo: 'openApiSpecFileShareService'
-      openApiSpecPath: 'file-share-service.openApi.yaml'
+      openApiSpecPath: '**/file-share-service.openApi.yaml'
       outputDirectory: '$(Build.SourcesDirectory)\src\UKHO.ADDS.Clients.FileShareService.ReadWrite\GeneratedClient'
       language: 'csharp'
       GeneratedApiClassName: 'KiotaFileShareServiceReadWrite'

--- a/deployment/KiotaClientGeneration.yml
+++ b/deployment/KiotaClientGeneration.yml
@@ -2,7 +2,7 @@ steps:
   - template: KiotaGenerateClients.yml
     parameters:
       openApiRepo: 'openApiSpecSalesCatalogueServiceSharedAssets'
-      openApiSpecPath: '**/salesCatalogue_ExchangeSetService_API_definition_v1.10.yaml'
+      openApiSpecPath: 'salesCatalogue_ExchangeSetService_API_definition_v1.10.yaml'
       outputDirectory: '$(Build.SourcesDirectory)\src\UKHO.ADDS.Clients.SalesCatalogueService\GeneratedClient'
       language: 'csharp'
       GeneratedApiClassName: 'KiotaSalesCatalogueService'
@@ -11,7 +11,7 @@ steps:
   - template: KiotaGenerateClients.yml
     parameters:
       openApiRepo: 'openApiSpecFileShareService'
-      openApiSpecPath: '**/file-share-service.openApi-public.yaml'
+      openApiSpecPath: 'file-share-service.openApi-public.yaml'
       outputDirectory: '$(Build.SourcesDirectory)\src\UKHO.ADDS.Clients.FileShareService.ReadOnly\GeneratedClient'
       language: 'csharp'
       GeneratedApiClassName: 'KiotaFileShareServiceReadOnly'
@@ -20,7 +20,7 @@ steps:
   - template: KiotaGenerateClients.yml
     parameters:
       openApiRepo: 'openApiSpecFileShareService'
-      openApiSpecPath: '**/file-share-service.openApi.yaml'
+      openApiSpecPath: 'file-share-service.openApi.yaml'
       outputDirectory: '$(Build.SourcesDirectory)\src\UKHO.ADDS.Clients.FileShareService.ReadWrite\GeneratedClient'
       language: 'csharp'
       GeneratedApiClassName: 'KiotaFileShareServiceReadWrite'

--- a/deployment/KiotaGenerateClients.yml
+++ b/deployment/KiotaGenerateClients.yml
@@ -17,8 +17,8 @@ parameters:
     type: string
 
 steps:
-  - checkout: ${{parameters.openApiRepo}}
-    path: s/openapi
+  # - checkout: ${{parameters.openApiRepo}}
+  #   path: s/openapi
 
   - task: UseDotNet@2
     displayName: 'Install .NET SDK for Kiota'

--- a/deployment/KiotaGenerateClients.yml
+++ b/deployment/KiotaGenerateClients.yml
@@ -35,7 +35,7 @@ steps:
 
   - powershell: |
       & "deployment\RunKiota.ps1" `
-        -OpenApiSpecPath "${{ parameters.openApiSpecPath }}" `
+        -OpenApiSpecPath "deployment\${{ parameters.openApiSpecPath }}" `
         -OutputDirectory "${{parameters.outputDirectory}}" `
         -Language "${{parameters.language}}" `
         -GeneratedApiClassName "${{parameters.GeneratedApiClassName}}" `

--- a/deployment/KiotaGenerateClients.yml
+++ b/deployment/KiotaGenerateClients.yml
@@ -35,7 +35,7 @@ steps:
 
   - powershell: |
       & "deployment\RunKiota.ps1" `
-        -OpenApiSpecPath "openapi\${{ parameters.openApiSpecPath }}" `
+        -OpenApiSpecPath "${{ parameters.openApiSpecPath }}" `
         -OutputDirectory "${{parameters.outputDirectory}}" `
         -Language "${{parameters.language}}" `
         -GeneratedApiClassName "${{parameters.GeneratedApiClassName}}" `

--- a/deployment/file-share-service.openApi-public.yaml
+++ b/deployment/file-share-service.openApi-public.yaml
@@ -1,0 +1,857 @@
+openapi: 3.0.1
+info:
+  title: UKHO File Share Service APIs
+  description: |
+    The UKHO File Share Service APIs allow querying and downloading of files from the File Share Service.
+  contact:
+    email: martin.rock-evans@ukho.gov.uk
+    name: Martin Rock-Evans
+  version: 0.0.4
+servers:
+  - url: http://fss.ukho.gov.uk
+    description: Proposed Live URL
+security:
+  - jwtBearerAuth: []
+paths:
+  /batch:
+    get:
+      summary: List non-expired batches.
+      operationId: getBatches
+      description: |
+        Returns a list of batches in FSS with their files. Only committed batches that have not expired will be returned.
+      parameters:
+        - $ref: "#/components/parameters/paginationLimit"
+        - $ref: "#/components/parameters/paginationStart"
+        - $ref: "#/components/parameters/batchAndFileFilter"
+      responses:
+        200:
+          description: OK - returns a list of batches.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: Number of batches that are in this page of the result. If there is only one page of results, this will equal `total`.
+                  total:
+                    type: integer
+                    description: Total number of batches that match the query.
+                  entries:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/batchDetails"
+                  _links:
+                    $ref: "#/components/schemas/_links"
+        400:
+          description: |
+            Bad request - there are one or more errors in the specified parameters, for example: a malformed query in the $filter; a request for results beyond the total count; an invalid page size (limit).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}/status:
+    get:
+      summary: Display the status of a batch
+      operationId: getBatchStatus
+      description: |
+        Returns the status of a batch. A batch status can be Incomplete, CommitInProgress, Committed, Rolledback or Failed.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      responses:
+        200:
+          description: OK - returns the status of the batch.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  batchId:
+                    type: string
+                    format: GUID
+                  status:
+                    type: string
+                    enum:
+                      [
+                        Incomplete,
+                        CommitInProgress,
+                        Committed,
+                        Rolledback,
+                        Failed,
+                      ]
+        400:
+          description: Bad request - Could be a bad batch ID or a batch ID that doesn't exist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        410:
+          $ref: "#/components/responses/batchGone"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}/files:
+    get:
+      summary: Download batch as zip.
+      operationId: getFilesAsZip
+      description: Download all the files in a batch as a single Zip file.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID (GUID).
+          required: true
+          schema:
+            type: string
+            format: GUID
+        - $ref: "#/components/parameters/range"
+
+      responses:
+        200:
+          description: OK - returns the file content.
+          headers:
+            Content-Length:
+              description: The size of the content returned in bytes. This will also be the full file size.
+              schema:
+                type: integer
+            Last-Modified:
+              description: Returns the date and time the file was last modified. The date is in RFC 1123 format.
+              schema:
+                type: string
+                format: date-time
+            Content-Type:
+              description: The content type specified for the file. If no content type was specified, the default content type is `application/octet-stream`.
+              schema:
+                type: string
+                format: MIME
+            Accept-Ranges:
+              description: The `Accept-Ranges` header indicates the that the service supports range requests for the target resource. This response will include `Accept-Ranges:bytes` to indicate that a partial range request is supported.
+              schema:
+                type: string
+            Content-Disposition:
+              description: The `Content-Disposition` header indicates that the response should be downloaded and saved, along with the suggested filename. e.g. `Content-Disposition:attachment; filename="filename.jpg"`.
+              schema:
+                type: string
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
+        206:
+          $ref: "#/components/responses/partialContent"
+        307:
+          $ref: "#/components/responses/redirect"
+        400:
+          description: Bad request - Could be a bad batch ID or a batch ID that doesn't exist; a bad format in the range header (note that invalid values in the range header would result in a 416 response (Range Not Satisfiable)).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        404:
+          description: |
+            File not found - The whole batch zip is not ready yet, but may be available in the future. Subsequent requests by the client are expected.
+
+            Creation of the whole batch zip file is a background process. The service will return 404 on this endpoint until the whole batch zip file is ready.
+        410:
+          $ref: "#/components/responses/batchGone"
+        416:
+          description: |
+            Range Not Satisfiable - If the offset in the Range header is invalid and exceeds the file’s total length, the request will return status code 416 (Range Not Satisfiable).
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}/files/{filename}:
+    get:
+      summary: Download a file
+      operationId: getFile
+      description: Downloads an individual specified file from FSS.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID (GUID).
+          required: true
+          schema:
+            type: string
+            format: GUID
+        - name: filename
+          in: path
+          description: Filename of the file.
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/range"
+
+      responses:
+        200:
+          description: OK - returns the file content.
+          headers:
+            Content-Length:
+              description: The size of the content returned in bytes. This will also be the full file size.
+              schema:
+                type: integer
+            Last-Modified:
+              description: Returns the date and time the file was last modified. The date is in RFC 1123 format.
+              schema:
+                type: string
+                format: date-time
+            Content-Type:
+              description: The content type specified for the file. If no content type was specified, the default content type is `application/octet-stream`.
+              schema:
+                type: string
+                format: MIME
+            Accept-Ranges:
+              description: The `Accept-Ranges` header indicates the that the service supports range requests for the target resource. This response will include `Accept-Ranges:bytes` to indicate that a partial range request is supported.
+              schema:
+                type: string
+            Content-Disposition:
+              description: The `Content-Disposition` header indicates that the response should be downloaded and saved, along with the suggested filename. e.g. `Content-Disposition:attachment; filename="filename.jpg"`.
+              schema:
+                type: string
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
+        206:
+          $ref: "#/components/responses/partialContent"
+        307:
+          $ref: "#/components/responses/redirect"
+        400:
+          description: Bad request - Could be a bad batch ID; a batch ID that doesn't exist; a bad filename; a bad format in the range header (note that invalid values in the range header would result in a 416 response (Range Not Satisfiable)).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        404:
+          description: File not found.
+        410:
+          $ref: "#/components/responses/batchGone"
+        416:
+          description: |
+            Range Not Satisfiable - If the offset in the Range header is invalid and exceeds the file’s total length, the request will return status code 416 (Range Not Satisfiable).
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}:
+    get:
+      summary: Get details of the batch including links to all the files in the batch.
+      operationId: getBatchDetails
+      description: |
+        This get will include full details of the batch, for example it's status, the files in the batch.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      responses:
+        200:
+          description: OK - Return details about the batch.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/batchDetails"
+        400:
+          description: Bad request - could be an invalid batch ID format. Batch IDs should be a GUID. A valid GUID that doesn't match a batch ID will return status code 404 (Not Found).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        404:
+          description: Not Found - Could be that the batch ID doesn't exist.
+        410:
+          $ref: "#/components/responses/batchGone"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /attributes:
+    get:
+      summary: Get a list of batch attributes.
+      operationId: getBatchAttributesList
+      description: Get a list of the batch attributes that have been applied to batches that the user has access to and can be used to query the list of batches.
+      responses:
+        200:
+          description: Returns a list of the batch attributes that exist, in order of the ones applied to the most batches first.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              example:
+                [
+                  "Product Type",
+                  "Year",
+                  "Product ID",
+                  "Media Type",
+                  "Exchange Set Type",
+                  "Week Number",
+                  "S63 Version",
+                ]
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /attributes/search:
+    get:
+      summary: Get a list of batch attributes and their values for a batch search.
+      operationId: getBatchAttributesAndValuesForSearch
+      description: |
+        Get a list of the batch attributes and their values that have been applied to batches for a batch search.
+      parameters:
+        - $ref: "#/components/parameters/batchAndFileFilter"
+        - $ref: "#/components/parameters/batchAttributeValueMaxCount"
+      responses:
+        200:
+          description: |
+            Returns a dictionary of the batch attributes and values that exist for the batches identified by the search.
+
+            Note : Some attributes (such as `TraceID`) are excluded from this list because they are likely to unique values for each batch. Also, the number of values returned for each attribute is limited to 25. If the attribute value list is truncated, the last entry will be `...`.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  searchBatchCount:
+                    type: integer
+                    description: Total number of batches that match the query.
+                  batchAttributes:
+                    type: object
+                    additionalProperties:
+                      type: array
+                      items:
+                        type: string
+              example:
+                {
+                  "searchBatchCount": 123,
+                  "batchAttributes":
+                    {
+                      "Product Type": ["AVCS", "ADP"],
+                      "Year": ["2021", "2022"],
+                      "Media Type": ["CD", "DVD", "Zip"],
+                      "Exchange Set Type": ["Base", "Update"],
+                      "Week Number":
+                        [
+                          "24",
+                          "25",
+                          "26",
+                          "27",
+                          "28",
+                          "29",
+                          "30",
+                          "31",
+                          "32",
+                          "33",
+                          "34",
+                          "35",
+                          "36",
+                          "37",
+                          "38",
+                          "39",
+                          "40",
+                          "41",
+                          "42",
+                          "43",
+                          "44",
+                          "45",
+                          "46",
+                          "47",
+                          "48",
+                          "...",
+                        ],
+                      "S63 Version": ["1.2"],
+                    }
+                }
+        400:
+          description: |
+            Bad request - there are one or more errors in the specified parameters, for example: a malformed query in the $filter.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+  /auth/client_credentials:
+    post:
+      summary: Get token from AAD.
+      operationId: getTokenUsingClientCredentials
+      description: |
+        Returns a token direct from AAD using Client Credentials.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                client_id:
+                  type: string
+                  description: The application ID that's assigned to the distributor's app. This will be provided to the distributor when they register their application.
+                client_secret:
+                  type: string
+                  description: The client secret that was generated for the distributor's app when the app was registered. The client secret must be URL-encoded before being sent.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token_type:
+                    type: string
+                  expires_in:
+                    type: string
+                  ext_expires_in:
+                    type: string
+                  access_token:
+                    type: string
+              example: |
+                {
+                  "token_type": "Bearer",
+                  "expires_in": 3599,
+                  "ext_expires_in": 3599,
+                  "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Imwzc1EtNTBjQ0g0eEJWWkxIVEd3blNSNzY4MCJ9.eyJhdWQiOiI0ZTE1NGYyYi0wNWM2LTQwZDEtODdiNy0wYWYwNTI5ZTBhNTEiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZTkyYzk4MWItZDY4OS00Y2MzLTgyNDUtMGQ3MTBlMjQ2YmNhL3YyLjAiLCJpYXQiOjE2MzI0NzU1OTAsIm5iZiI6MTYzMjQ3NTU5MCwiZXhwIjoxNjMyNDc5NDkwLCJhaW8iOiJFMlpnWUdpZTJhSmhQT0ZDWTdQR3NxYUhaWi9tQXdBPSIsImF6cCI6IjJmMzJmNmY3LTFmMmYtNDNjZS1hZmQ3LWYzM2Y5M2NiN2U2MSIsImF6cGFjciI6IjEiLCJvaWQiOiJkNmY4ZDg0My0zZTY1LTQ5YTAtODdkNy0zMTBkMGNiM2UzOGUiLCJyaCI6IjAuQVNJQUc1Z3M2WW5XdzB5Q1JRMXhEaVJyeXZmMk1pOHZIODVEcjlmelA1UExmbUVpQUFBLiIsInN1YiI6ImQ2ZjhkODQzLTNlNjUtNDlhMC04N2Q3LTMxMGQwY2IzZTM4ZSIsInRpZCI6ImU5MmM5ODFiLWQ2ODktNGNjMy04MjQ1LTBkNzEwZTI0NmJjYSIsInV0aSI6IlREVmtmenZuS2txVEdRUXNEWjItQUEiLCJ2ZXIiOiIyLjAifQ.W-TB97v6D56UuPCstaSrfLFbc9gE6W1VHD5t0RLo_EK-1LuaTvQ0aqJtaYCRnXnd6RmMIIml3ckHxFL0lZlYUoSjszIMFkb1w0aH5SxD-GOfY-dktvGKdMVxqtyjJJg1IV7V3Dv1BYI24RnGPfcJG73-af7vcTRjE5KFeW_kOMVAfCAcZOV9dJ7BJULfEdHlK8ZFUb2hEzFkoORGdlrpNIJ7-QEhB9Kcnxa9QtA4z8lMtWESx-q17N88fmlaz87kEKEjX3pIP7k2l_y5BNtNAxK0h995pZ9hHNe4-UBH-xjvfuDa6IbCsZD1J1IW7AO1bXCjGGvc31PtJqEc5FRdQQ"
+                }
+        400:
+          description: Bad request - Request missing client_id and/or client_secret.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+              example:
+                {
+                  "correlationId": "184ef711-b039-4c24-b81a-89081d8f324c",
+                  "errors":
+                    [
+                      {
+                        "source": "request",
+                        "description": "request missing client_id and/or client_secret"
+                      }
+                    ]
+                }
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+components:
+  parameters:
+    paginationLimit:
+      name: limit
+      description: Specify the limit of the number of results returned in one page. Also known as page size. Optional parameter and defaults to 10 results per page. If specified, must be greater or equal to 1.
+      in: query
+      required: false
+      schema:
+        type: integer
+    paginationStart:
+      name: start
+      description: Specify the index of the first item returned in the results. Defaults to 0 (the first item). Used with pagination. If specified, must be greater than or equal to 0. If greater than the number of results, the service will return status code 400 (Bad Request).
+      in: query
+      required: false
+      schema:
+        type: integer
+    batchAndFileFilter:
+      name: $filter
+      description: |
+        The search `$filter` allows callers to filter the returned results loosely based on the OData 4.01 `$filter` syntax (See <http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_QueryOptions> for a full description of the OData query options).
+
+
+        ## User Attributes
+
+        User attributes can be used as part of the filter with the attribute name enclosed within `$batch( )` or `$file( )` e.g. `$batch(Attribute Name)` or `$file(Attribute Name)`. User Attribute names are not case sensitive, e.g. `$batch(Product)` and `$Batch(product)` are the same.
+
+        This allows the string operators below to be used, for example: `$filter=$batch(Product) eq 'AVCS'` or `$filter=endswith($file(Week Number), '/52')`
+
+        Batches and files within the batch have user attributes. For filtering, a batch is considered to have the combination of its own attributes and all the attributes of the files in that batch. Operators will then match on any of the attributes, so an operator could match on one or more of the batch's attributes, or any of the file's attributes.
+
+        A batch that has no instances of the attribute and no files with an instance of the attribute will be considered to have a null value for that attribute. Combined with the `null` literal, this can be used to test for the presence or absence of a user attribute.  (e.g. `$filter=$batch(Product) eq null` will return batches that don't have a `Product` attribute and `$filter=$file(Product) eq null` will return all batches for which files don't have a `Product` attribute.)
+
+        **Note**: user attribute values can only be compared with a literal value. It is not possible to compare one user attribute value with another user attribute value. e.g. `$filter=$batch(Product) eq $batch(Service)` or `$filter=$file(Product) eq $file(Service)` is an invalid filter and will return HTTP Status Code 400 - Bad Request.
+
+        Additionally, you can search for any batch user attribute that has a value that contains a search term. `$batchContains('searchTerm')` will look for any batch with any attribute that contains the 'searchTerm'. Whereas `$batch()` and `$file()` are string functions, i.e. they return the value of the attribute to then be compared with an operator below, `$batchContains()` is a boolean function and returns true or false. `$batchContains()` can be combined with boolean operators such as and and or.
+
+
+        ## System Attributes
+
+        System attribute names are not case sensitive. For example: `batchPublishedDate` is the same as `batchpublisheddate`.
+
+        The service supports queries on the following system attributes:
+
+        * `businessUnit` - Matches a string, e.g. `$filter=businessUnit eq 'ADDS'`. Partial matches are supported using the string operators below. e.g. `$filter=startswith(businessUnit,'Test')`.
+        * `batchPublishedDate` - The date the batch was published (committed) (not the individual files, or the initial batch created date). Only matches against a date literal or expression. Dates must be specified in full date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z. The system supports the comparison operators listed below e.g. `$filter=batchPublishedDate gt 2020-12-23T17:45:12Z`.
+        * `expiryDate` - Only matches against a date literal or expression. Dates must be specified in full date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z. The system supports the comparison operators listed below. e.g. `$filter=expiryDate lt 2020-01-05T19:56:48Z`.
+        * `filename` - Matches a string which is the filename of any of the files within a batch, e.g. `$filter=filename eq 'AUL37137.004'`. This will also support partial filename matches using the string operators below. e.g. `$filter=endswith(filename,'.iso')`.
+        * `filesize` - Matches an integer that is the the file size in bytes of any of the files in the batch. The match can be made using `eq` and `ne` operator as well as the comparison operators listed below. e.g. `$filter=fileSize gt 1000000` finds any batch that contains one or more files that is bigger than 1000000 bytes (1MB).
+        * `mimetype` - Matches a string that is the MIME Type of any of the files in the batch.  Partial matches can be made with the string operators listed below. e.g. `$filter=startswith(mimeType, 'text')` would match `text/json` and `text/plain` but not `application/json`.
+
+        The following system attributes have been considered and are **not** currently in scope:
+
+        * ~~`hash` - Search for this binary object?~~
+        * ~~`totalBatchSize` - Match against the sum of all the file sizes of the files in the batch? Much harder to translate to a SQL query, but possibly more useful to the users?~~
+
+        **Note**: System Attribute values can only be compared with a literal value. It is not possible to compare one System Attribute value with another System Attribute value. e.g. `$filter=batchedPublishedDate gt expiryDate` is an invalid filter and will return HTTP Status Code 400 - Bad Request.
+
+        ## Supported Operators
+
+        Comparison between two values of different types will fail (e.g. you can't compare a string value and a date, the query will return status code 400 (Bad Request)).
+
+        * And (`and`) - This binary operator can be used between two expressions and will return true if both the left and right expression are true.
+        * Or (`or`) - This binary operator can be used between two expressions and will return true if either the left expression or the right expression is true.
+        * Not (`not`) - The `not` operator returns true if the operand returns false, otherwise it returns false.  e.g. `$filter=not endswith($batch(Product),'ilk') or not endswith($file(Product),'ilk').
+        * Equals (`eq`) - Comparison of two values to see if they are the same. For string values, the comparison is case-insensitive, so `'Bob' eq 'BOB'` will return true. For Date-Time values, the comparison is exact so `2017-07-21T17:32:28Z eq 2017-07-21T17:32:29Z` will return false.
+        * Not Equals (`ne`) - Comparison of two values to see if they are different. For string values, the comparison is case-insensitive, so `'Bob' ne 'BOB'` will return false. For Date-Time values, the comparison is exact so `2017-07-21T17:32:28Z ne 2017-07-21T17:32:29Z` will return true.
+        * Comparison operators (only applies to numeric system attributes (i.e. `filesize`) or date system attributes (i.e. `batchPublishedDate` and `expiryDate`)).
+          * Greater Than (`gt`) e.g. `fileSize gt 1000000` or `batchPublishedDate gt 2020-12-23T17:45:12Z`.
+          * Greater Than or Equals (`ge`) e.g. `fileSize ge 1000000` or `batchPublishedDate ge 2020-12-23T17:45:12Z`.
+          * Less Than (`lt`) e.g. `fileSize lt 1000000` or `batchPublishedDate lt 2020-12-23T17:45:12Z`.
+          * Less Than or Equals (`le`) e.g. `fileSize le 1000000` or `batchPublishedDate le 2020-12-23T17:45:12Z`.
+        * String operators:
+          * Contains (`contains()`).
+          * Starts With (`startswith()`).
+          * Ends With (`endswith()`) - This operator returns true if the value of the attribute is a string and ends with the provided literal. e.g. `endswith(filename,'.iso')`.
+          
+
+
+        **Note**: the system does not support any other Functions or Arithmetic Operators.
+
+
+        ## Literal values
+
+        The system supports the following literal values:
+
+        * Null (`null`).
+        * True (`true`).
+        * False (`false`).
+        * Integer values (e.g. `-128`).
+        * String values (e.g. `'Say Hello,then go'`).
+        * String values with single quote (e.g. `'Rob O'Neil'`) - Replace 1 single quote with 2 single quotes to search a value having single quote. e.g. `'Rob O''Neil'`
+        * DateTimeOffset values (e.g. `2012-12-03T07:16:23Z`). Dates must be specified in the RFC 3339 format. They can contain a date-time offset, but will be converted to UTC before comparison.
+
+
+        ## Operator Precedence
+
+        Operators are listed by category in order of precedence from highest to lowest. Operators in the same category have equal precedence:
+
+          | Group           | Operator | Description           |
+          |-----------------|----------|-----------------------|
+          | Grouping        | ( )      | Precedence grouping   |
+          | Primary         | xxx( )   | Method Call           |
+          | Unary           | not      | Logical Negation      |
+          | Relational      | gt       | Greater Than          |
+          |                 | ge       | Greater Than or Equal |
+          |                 | lt       | Less Than             |
+          |                 | le       | Less Than or Equal    |
+          | Equality        | eq       | Equal                 |
+          |                 | ne       | Not Equal             |
+          | Conditional AND | and      | Logical And           |
+          | Conditional OR  | or       | Logical Or            |
+
+        The Grouping operator (open and close parenthesis `( )`) controls the evaluation order of an expression. The Grouping operator returns the expression grouped inside the parenthesis, e.g.:
+
+        ```
+          $filter=($batch(Product Type) eq 'AVCS') and ($batch(Week Number) eq '12' or $batch(Week Number) eq '13')
+        ```
+
+        ## Examples:
+
+          `$filter=$batch(Product Type) eq 'AVCS' and $batch(Week Number) eq '12' and batchPublishedDate gt 2020-10-21T00:00:00Z` - All AVCS files for Week Number 2020/12 created after 21 Oct 2020.
+
+          `$filter=batchPublishedDate gt 2020-10-21T00:00:00Z` - All files created after midnight on 21 Oct 2020.
+          
+          `$filter=expiryDate lt 2020-12-21T00:00:00Z` - All files due to expire before 21 Dec 2020.
+
+          `$filter=`$batchContains('AVCS')`
+
+      in: query
+      required: false
+      schema:
+        type: string
+    batchAttributeValueMaxCount:
+      name: maxAttributeValueCount
+      description: Optional. Specify the maximum number of batch attribute values to be returned in the result. If specified, must be greater than or equal to 1. If less than 1, the service will return status code 400 (Bad Request).
+      in: query
+      required: false
+      schema:
+        type: integer
+
+    range:
+      name: Range
+      in: header
+      description: |
+        Optional. Return file data only for the specified byte range.
+
+        ### Format 1: `bytes=startByte-`
+
+        This range will return bytes from the offset startByte through to the end of the file. For example, to specify a range encompassing all bytes after the first 256 bytes of a file, you can pass in the following header:
+
+        ```
+          Range: bytes=255-
+        ```
+
+        The `Content-Length` header in the response is equal to the number of bytes from the offset until the end of the file. Using the example range above for a file of 1,024 bytes in length, `Content-Length` would be 769.
+
+        If the offset is valid and does not exceed the file’s total length, the request will return status code 206 (Partial Content). If the offset is invalid and exceeds the file’s total length, the request will return status code 416 (Range Not Satisfiable).
+
+        ### Format 2: `bytes=startByte-endByte`
+
+        This range will return bytes from the offset startByte through to the endByte. For example, to specify a range encompassing the first 512 bytes of a file, you would pass in the following header:
+
+        ```
+          Range: bytes=0-511
+        ```
+
+        The `Content-Length` header in the response is equal to the number of bytes between each offset. Using the example range above for a file of 1,024 bytes in length, `Content-Length` would be 512.
+
+        If the offset is valid and does not exceed the file’s total length, the request will return status code 206 (Partial Content). If the offset is invalid and exceeds the file’s total length, the request will return status code 416 (Range Not Satisfiable).
+
+        See Microsoft documentation for more details on specifying the range header: <https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-the-range-header-for-file-service-operations>, the HTTP Range Requests specification: <https://tools.ietf.org/html/rfc7233> or Byte serving information <https://en.wikipedia.org/wiki/Byte_serving>.
+      required: false
+      schema:
+        type: string
+        format: bytes=startByte-endByte or bytes=startByte-
+
+  responses:
+    unauthorised:
+      description: Unauthorised - either you have not provided any credentials, or your credentials are not recognised.
+
+    forbidden:
+      description: Forbidden - you have been authorised, but you are not allowed to access this resource.
+
+    batchGone:
+      description: Gone - the specified batch has expired and is no longer available.
+
+    tooManyRequests:
+      description: You have sent too many requests in a given amount of time. Please back-off for the time in the Retry-After header (in seconds) and try again.
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Specifies the time you should wait in seconds before retrying.
+
+    partialContent:
+      description: Partial Content - The response is a partial content because a Range was specified for a part of the file.
+      headers:
+        Accept-Ranges:
+          description: The `Accept-Ranges` header indicates the that the service supports range requests for the target resource. This response will include `Accept-Ranges:bytes` to indicate that a partial range request is supported.
+          schema:
+            type: string
+        Content-Disposition:
+          description: The `Content-Disposition` header indicates that the response should be downloaded and saved, along with the suggested filename. e.g. `Content-Disposition:attachment; filename="filename.jpg"`.
+          schema:
+            type: string
+        Content-Range:
+          description: |
+            Describes the part of the file that is actually returned.
+
+            ### Syntax
+
+            ```
+              Content-Range: <unit> <range-start>-<range-end>/<size>
+              Content-Range: <unit> <range-start>-<range-end>/*
+              Content-Range: <unit> */<size>
+            ```
+
+            `<unit>` The unit in which ranges are specified. This will be `bytes`.
+
+            `<range-start>` An integer in bytes indicating the beginning of the request range.
+
+            `<range-end>` An integer in bytes indicating the end of the requested range.
+
+            `<size>` The total size of the file.
+
+            Example:
+
+            ```
+              Content-Range: bytes 200-1000/67589
+            ```
+          schema:
+            type: string
+        Content-Length:
+          description: The size of the content returned in bytes. This will be less than the full file size.
+          schema:
+            type: integer
+        Last-Modified:
+          description: Returns the date and time the file was last modified. The date is in RFC 1123 format.
+          schema:
+            type: string
+            format: date-time
+        Content-Type:
+          description: The content type specified for the file. If no content type was specified, the default content type is `application/octet-stream`.
+          schema:
+            type: string
+            format: MIME
+      content:
+        "*/*":
+          schema:
+            type: string
+            format: binary
+    redirect:
+      description: |
+        Temporary Redirect - the file should be downloaded from the URL provided in the `Location` header.
+
+        For reasons of download performance, when downloading a large file the client will be redirected to a direct/accelerated URL. The URL may include a temporary access token. The request to the URL should be a `GET` request with the full URL including any query parameters. No additional headers (including authorize headers) will be required.
+
+        Note - the redirect URL is likely to have a time and/or IP address limited access token attached to it, so should not be stored.
+      headers:
+        Location:
+          description: The absolute URL the file should be downloaded from, including any access tokens required.
+          schema:
+            type: string
+            format: URL
+
+  schemas:
+    errorDescription:
+      type: object
+      properties:
+        correlationId:
+          type: string
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/fieldError"
+
+    fieldError:
+      type: object
+      properties:
+        source:
+          type: string
+        description:
+          type: string
+
+    href:
+      type: string
+      format: uri
+    link:
+      type: object
+      properties:
+        href:
+          $ref: "#/components/schemas/href"
+
+    _links:
+      description: Links, usually describing links to next and previous pages in a paged result.
+      type: object
+      properties:
+        self:
+          description: Link to this page of the results.
+          $ref: "#/components/schemas/link"
+        first:
+          description: Link to the first page of the results. Will be the same as self if this is the first page.
+          $ref: "#/components/schemas/link"
+        previous:
+          description: Link to the previous page of results if there are any.
+          $ref: "#/components/schemas/link"
+        next:
+          description: Link to the next page of results if there are any.
+          $ref: "#/components/schemas/link"
+        last:
+          description: Link to the last page of results if there are any.
+          $ref: "#/components/schemas/link"
+
+    batchDetails:
+      description: Object representing the details of a batch.
+      type: object
+      properties:
+        batchId:
+          type: string
+          format: GUID
+        status:
+          type: string
+          enum: [Incomplete, CommitInProgress, Committed, Rolledback, Failed]
+        allFilesZipSize:
+          type: integer
+        attributes:
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+        businessUnit:
+          type: string
+        batchPublishedDate:
+          type: string
+          format: date-time
+        expiryDate:
+          type: string
+          format: date-time
+        isAllFilesZipAvailable:
+          description: Indicates if the zip of all files in the batch is available. See "#/paths/batch/{batchId}/files"
+          type: boolean
+        files:
+          type: array
+          items:
+            type: object
+            properties:
+              filename:
+                type: string
+              fileSize:
+                type: integer
+              mimeType:
+                type: string
+                description: The MIME content type of the file.
+              hash:
+                type: string
+                format: Base64
+                description: MD5 hash of the file content.
+              attributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+              links:
+                type: object
+                description: Contains links to the relevant APIs for this file.
+                properties:
+                  get:
+                    $ref: "#/components/schemas/link"
+
+  securitySchemes:
+    jwtBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/deployment/file-share-service.openApi.yaml
+++ b/deployment/file-share-service.openApi.yaml
@@ -1,0 +1,1679 @@
+openapi: 3.0.1
+info:
+  title: UKHO File Share Service APIs
+  description: |
+    The UKHO File Share Service APIs allow querying and downloading of files from the File Share Service.
+
+    The tags have been used to indicate where a subset of the APIs are required by a specific project. As FSS matures and becomes a complete implementation, these future project specific tags may be removed.
+  contact:
+    email: martin.rock-evans@ukho.gov.uk
+    name: Martin Rock-Evans
+  version: 0.0.4
+servers:
+  - url: http://fss.ukho.gov.uk
+    description: Proposed Live URL
+  - url: https://fss-qa-webapp.azurewebsites.net
+    description: UKHO Test service only
+  - url: https://fss-dev-webapp.azurewebsites.net
+    description: UKHO Dev service only
+tags:
+  - name: public
+    description: APIs that could be used by any member of the public to access the FSS content.
+  - name: UKHO Only
+security:
+  - jwtBearerAuth: []
+paths:
+  /batch:
+    get:
+      tags:
+        - public
+      summary: List non-expired batches.
+      operationId: getBatches
+      description: |
+        Returns a list of batches in FSS with their files. Only committed batches that have not expired will be returned.
+      parameters:
+        - $ref: "#/components/parameters/paginationLimit"
+        - $ref: "#/components/parameters/paginationStart"
+        - $ref: "#/components/parameters/batchAndFileFilter"
+      responses:
+        200:
+          description: OK - returns a list of batches.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: Number of batches that are in this page of the result. If there is only one page of results, this will equal `total`.
+                  total:
+                    type: integer
+                    description: Total number of batches that match the query.
+                  entries:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/batchDetails"
+                  _links:
+                    $ref: "#/components/schemas/_links"
+          links:
+            getFile:
+              operationId: getFile
+              parameters:
+                $url: "$response.body#/entries/1/files/1/links/get/href"
+                batchId: "$response.body#/entries/1/batchId"
+                filename: "$response.body#/entries/1/files/1/filename"
+            self:
+              operationId: getBatches
+              parameters:
+                $filter: "$request.query.$filter"
+                limit: "$request.query.limit"
+                start: "$request.query.start"
+            firstPage:
+              operationId: getBatches
+              parameters:
+                $filter: "$request.query.$filter"
+                limit: "$request.query.limit"
+                start: "0"
+            previousPage:
+              operationId: getBatches
+              parameters:
+                $filter: "$request.query.$filter"
+                limit: "$request.query.limit"
+                start: "$request.query.start - $request.query.limit"
+            nextPage:
+              operationId: getBatches
+              parameters:
+                $filter: "$request.query.$filter"
+                limit: "$request.query.limit"
+                start: "$request.query.start + $request.query.limit"
+            lastPage:
+              operationId: getBatches
+              parameters:
+                $filter: "$request.query.$filter"
+                limit: "$request.query.limit"
+                start: "$response.body.total - $request.query.limit"
+        400:
+          description: |
+            Bad request - there are one or more errors in the specified parameters, for example: a malformed query in the $filter; a request for results beyond the total count; an invalid page size (limit).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+    post:
+      tags:
+        - UKHO Only
+      summary: Create a new batch to upload files into.
+      operationId: startBatch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - businessUnit
+              properties:
+                businessUnit:
+                  type: string
+                  description: The business unit that this data is being hosted for.
+                acl:
+                  type: object
+                  description: The ACL describes which users or groups will be able to read files in this batch once it has been committed.
+                  properties:
+                    readUsers:
+                      description: List of AD/B2C Object IDs for the individual users that can read this batch.
+                      type: array
+                      items:
+                        type: string
+                    readGroups:
+                      description: List of group names that can read this batch.
+                      type: array
+                      items:
+                        type: string
+                attributes:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - key
+                      - value
+                    properties:
+                      key:
+                        type: string
+                      value:
+                        type: string
+                expiryDate:
+                  type: string
+                  format: date-time
+                  description: Optional expiry date for the batch.
+      responses:
+        201:
+          description: Created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  batchId:
+                    type: string
+                    format: GUID
+        400:
+          description: |
+            Bad request - there are one or more errors in the specified parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}/status:
+    get:
+      tags:
+        - public
+      summary: Display the status of a batch
+      operationId: getBatchStatus
+      description: |
+        Returns the status of a batch. A batch status can be Incomplete, CommitInProgress, Committed, Rolledback or Failed.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      responses:
+        200:
+          description: OK - returns the status of the batch.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  batchId:
+                    type: string
+                    format: GUID
+                  status:
+                    type: string
+                    enum:
+                      [
+                        Incomplete,
+                        CommitInProgress,
+                        Committed,
+                        Rolledback,
+                        Failed,
+                      ]
+        400:
+          description: Bad request - Could be a bad batch ID or a batch ID that doesn't exist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        410:
+          $ref: "#/components/responses/batchGone"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}/files:
+    get:
+      tags:
+        - public
+      summary: Download batch as zip.
+      operationId: getFilesAsZip
+      description: Download all the files in a batch as a single Zip file.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID (GUID).
+          required: true
+          schema:
+            type: string
+            format: GUID
+        - $ref: "#/components/parameters/range"
+
+      responses:
+        200:
+          description: OK - returns the file content.
+          headers:
+            Content-Length:
+              description: The size of the content returned in bytes. This will also be the full file size.
+              schema:
+                type: integer
+            Last-Modified:
+              description: Returns the date and time the file was last modified. The date is in RFC 1123 format.
+              schema:
+                type: string
+                format: date-time
+            Content-Type:
+              description: The content type specified for the file. If no content type was specified, the default content type is `application/octet-stream`.
+              schema:
+                type: string
+                format: MIME
+            Accept-Ranges:
+              description: The `Accept-Ranges` header indicates the that the service supports range requests for the target resource. This response will include `Accept-Ranges:bytes` to indicate that a partial range request is supported.
+              schema:
+                type: string
+            Content-Disposition:
+              description: The `Content-Disposition` header indicates that the response should be downloaded and saved, along with the suggested filename. e.g. `Content-Disposition:attachment; filename="filename.jpg"`.
+              schema:
+                type: string
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
+        206:
+          $ref: "#/components/responses/partialContent"
+        307:
+          $ref: "#/components/responses/redirect"
+        400:
+          description: Bad request - Could be a bad batch ID or a batch ID that doesn't exist; a bad format in the range header (note that invalid values in the range header would result in a 416 response (Range Not Satisfiable)).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        404:
+          description: |
+            File not found - The whole batch zip is not ready yet, but may be available in the future. Subsequent requests by the client are expected.
+
+            Creation of the whole batch zip file is a background process. The service will return 404 on this endpoint until the whole batch zip file is ready.
+        410:
+          $ref: "#/components/responses/batchGone"
+        416:
+          description: |
+            Range Not Satisfiable - If the offset in the Range header is invalid and exceeds the file’s total length, the request will return status code 416 (Range Not Satisfiable).
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}/files/{filename}:
+    get:
+      tags:
+        - public
+      summary: Download a file
+      operationId: getFile
+      description: Downloads an individual specified file from FSS.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID (GUID).
+          required: true
+          schema:
+            type: string
+            format: GUID
+        - name: filename
+          in: path
+          description: Filename of the file.
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/range"
+
+      responses:
+        200:
+          description: OK - returns the file content.
+          headers:
+            Content-Length:
+              description: The size of the content returned in bytes. This will also be the full file size.
+              schema:
+                type: integer
+            Last-Modified:
+              description: Returns the date and time the file was last modified. The date is in RFC 1123 format.
+              schema:
+                type: string
+                format: date-time
+            Content-Type:
+              description: The content type specified for the file. If no content type was specified, the default content type is `application/octet-stream`.
+              schema:
+                type: string
+                format: MIME
+            Accept-Ranges:
+              description: The `Accept-Ranges` header indicates the that the service supports range requests for the target resource. This response will include `Accept-Ranges:bytes` to indicate that a partial range request is supported.
+              schema:
+                type: string
+            Content-Disposition:
+              description: The `Content-Disposition` header indicates that the response should be downloaded and saved, along with the suggested filename. e.g. `Content-Disposition:attachment; filename="filename.jpg"`.
+              schema:
+                type: string
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: binary
+        206:
+          $ref: "#/components/responses/partialContent"
+        307:
+          $ref: "#/components/responses/redirect"
+        400:
+          description: Bad request - Could be a bad batch ID; a batch ID that doesn't exist; a bad filename; a bad format in the range header (note that invalid values in the range header would result in a 416 response (Range Not Satisfiable)).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        404:
+          description: File not found.
+        410:
+          $ref: "#/components/responses/batchGone"
+        416:
+          description: |
+            Range Not Satisfiable - If the offset in the Range header is invalid and exceeds the file’s total length, the request will return status code 416 (Range Not Satisfiable).
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+    post:
+      tags:
+        - UKHO Only
+      summary: Add a file to the batch
+      operationId: addFileToBatch
+      description: |
+        Creates a file in the batch. To upload the content of the file, one or more `uploadBlockOfFile` requests will need to be made followed by a 'putBlocksInFile' request to complete the file.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+        - name: filename
+          in: path
+          description: Filename for the new file. Must be unique in the batch (but can be the same as another file in another batch). Filenames don't include a path.
+          required: true
+          schema:
+            type: string
+        - name: X-MIME-Type
+          in: header
+          description: Optional. The MIME content type of the file. The default type is application/octet-stream.
+          required: false
+          schema:
+            type: string
+            format: MIME
+        - name: X-Content-Size
+          in: header
+          description: The final size of the file in bytes.
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                attributes:
+                  description: Additional attributes that apply to this file (in addition to the attributes applied to the batch).
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - key
+                      - value
+                    properties:
+                      key:
+                        type: string
+                      value:
+                        type: string
+      responses:
+        201:
+          description: Created
+        400:
+          description: Bad request - Could be a bad batch ID; a batch ID that doesn't exist; a bad filename.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        409:
+          description: Conflict - there is an existing file with that name already.
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+    put:
+      tags:
+        - UKHO Only
+      summary: Write blocks to a file
+      operationId: putBlocksInFile
+      description: |
+        It creates a file using the list of Block IDs for that filename.
+
+        All blocks must have been successfully uploaded using `/batch/{batchId}/files/{filename}/{blockId}` prior to calling this operation.
+
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID
+          required: true
+          schema:
+            type: string
+            format: GUID
+        - name: filename
+          in: path
+          description: Filename for the file. The file must have already been created in the batch using '#/paths/batch/{batchId}/files/{filename}/post'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: |
+          List of block Ids in the order in which blocks are to be combined to create the file.
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - blockIds
+              properties:
+                blockIds:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        204:
+          description: No Content
+        400:
+          description: Bad request - could be one of - invalid or non-existing batch ID; invalid or non-existing filename; empty Block ID list; or invalid Block ID(s) supplied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}/files/{filename}/{blockId}:
+    put:
+      tags:
+        - UKHO Only
+      summary: Uploads a block of byte data for future inclusion in a file.
+      operationId: uploadBlockOfFile
+      description: |
+        It uploads block of bytes data for future inclusion in a file.
+
+        Each block is identified by a block ID that is unique for a file. Block IDs are scoped to a particular file, so different files can have blocks with same IDs. Each block can be of a different size, up to any set max limit. An uploaded block can be used only in the file for which it was uploaded.
+
+        Blocks can be uploaded in parallel, in any order. Once all blocks have been uploaded, use the 'putBlocksInFile' operation to create a file using the list of Block IDs for that file.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+        - name: filename
+          in: path
+          description: Filename for the file. The file must have already been added to the batch using '#/paths/batch/{batchId}/files/{filename}/post'.
+          required: true
+          schema:
+            type: string
+        - name: blockId
+          in: path
+          description: A Block ID. It must be less than or equal to 64 bytes in size. For a given file, the length of the value specified for the blockid parameter must be the same size for each block.
+          required: true
+          schema:
+            type: string
+        - name: Content-Length
+          in: header
+          description: |
+            Required. Specifies the number of bytes being transmitted in the request body.
+
+            The block must be less than or equal to the size limit set for individual block.
+          required: true
+          schema:
+            type: integer
+        - name: Content-MD5
+          in: header
+          description: |
+            Required. A Base64-encoded MD5 hash of the block content. This hash is used to verify the integrity of the block during transport.
+
+            If hash matching fails, the operation will return status code 400 (Bad Request).
+
+            Note - this MD5 hash is not stored with the file.
+          required: true
+          schema:
+            type: string
+            format: byte
+        - name: Content-Type
+          in: header
+          description: |
+            Required. The value should be "application/octet-stream".
+          required: true
+          schema:
+            type: string
+            format: MIME
+      requestBody:
+        description: |
+          The chunk of file content as specified by the Content-Length header.
+        content:
+          "*/*":
+            schema:
+              type: string
+              format: binary
+      responses:
+        201:
+          description: Created
+        400:
+          description: Bad request - Could be a bad batch ID; a batch ID that doesn't exist; a bad filename or the filename doesn't exist; a badly formed block id; or MD5 hash mismatch.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        413:
+          description: Payload too large - The chunk you are trying to upload is too large as per content length header
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}:
+    get:
+      tags:
+        - public
+      summary: Get details of the batch including links to all the files in the batch.
+      operationId: getBatchDetails
+      description: |
+        This get will include full details of the batch, for example it's status, the files in the batch.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      responses:
+        200:
+          description: OK - Return details about the batch.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/batchDetails"
+        400:
+          description: Bad request - could be an invalid batch ID format. Batch IDs should be a GUID. A valid GUID that doesn't match a batch ID will return status code 404 (Not Found).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        404:
+          description: Not Found - Could be that the batch ID doesn't exist.
+        410:
+          $ref: "#/components/responses/batchGone"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+    put:
+      tags:
+        - UKHO Only
+      summary: Commit the batch
+      operationId: commitBatch
+      description: |
+        Starts the commit process for a batch. On completion, the files in the batch have been committed to FSS and are ready to query/download.
+
+        Note - this can be a long running task as it involves moving files to BU storage account.
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                required:
+                  - filename
+                properties:
+                  filename:
+                    type: string
+                    description: Name of file.
+                  hash:
+                    type: string
+                    format: Base64
+                    description: Optional MD5 hash of the file content. If the hash is provided the full contents of the actual file will be validated against the hash during the asynchronous commit process. A mismatch between file contents and the hash will cause the batch commit to fail and the batch status will show `Failed`.
+      responses:
+        202:
+          description: Accepted - Request for batch commit is accepted. Client can use uri in the response body to check batch status.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: object
+                    properties:
+                      uri:
+                        type: string
+                        format: uri
+                        example: /batch/0f8fad5b-d9cb-469f-a165-70867728950e/status
+        400:
+          description: Bad request - Could be that the batch ID doesn't exist; no files associated with batch; no files written for batch; file name provided in request body is empty; or doesn't exist or vice-versa; file hash provided doesn't match with calculated hash.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        409:
+          description: Conflict - the batch has already been rolled back/abandoned. Multiple calls to commitBatch are idempotent in that if the batch was successfully committed, further calls to commitBatch will succeed.
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+    delete:
+      tags:
+        - UKHO Only
+      summary: Rollback/Abandon the batch
+      operationId: rollbackBatch
+      description: |
+        Rollback/Abandon a batch that is still being staged.
+
+        This should be an idempotent request, i.e. you can call delete on a batch and you'll get the same response every time.
+
+        Once a batch has been committed, it can't be rolled back (and will return status code 409 (Conflict)).
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      responses:
+        204:
+          description: No Content.
+        400:
+          description: Bad request - The batch ID is malformed or doesn't exit; or bad batch ID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        409:
+          description: Conflict - the batch has already been committed. Multiple calls to commitBatch are idempotent in that if the batch was successfully committed, further calls to commitBatch will succeed.
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}/acl:
+    get:
+      tags:
+        - UKHO Only
+      summary: Get the current Access Control Lists.
+      operationId: getAcl
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      responses:
+        200:
+          description: Returns the current Access Control List for the batch.
+          content:
+            application/json:
+              schema:
+                type: object
+                description: The ACL describes which users or groups will be able to read files in this batch once it has been committed.
+                properties:
+                  readUsers:
+                    description: List of AD/B2C Object IDs for the individual users that can read this batch.
+                    type: array
+                    items:
+                      type: string
+                  readGroups:
+                    description: List of group names that can read this batch.
+                    type: array
+                    items:
+                      type: string
+        400:
+          description: Bad request - Could be that the batch ID format is invalid or it doesn't exist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        410:
+          $ref: "#/components/responses/batchGone"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+    post:
+      tags:
+        - UKHO Only
+      summary: Append new entries to the current Access Control List for the batch.
+      operationId: appendAcl
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              description: As this is an append, at least one entry must be provided in `readUsers` or `readGroups` (or both).
+              properties:
+                readUsers:
+                  description: Optional list of additional AD/B2C Object IDs for the individual users that can read this batch.
+                  type: array
+                  items:
+                    type: string
+                readGroups:
+                  description: Optional list of additional group names that can read this batch.
+                  type: array
+                  items:
+                    type: string
+      responses:
+        204:
+          description: No Content - the ACL has been modified.
+        400:
+          description: Bad request - Could be that the batch ID doesn't exist; the body content is in an invalid format; or both readUsers and readGroups are null or empty.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        410:
+          $ref: "#/components/responses/batchGone"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+    put:
+      tags:
+        - UKHO Only
+      summary: Replace the entire Access Control List for this batch.
+      operationId: replaceAcl
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              description: The ACL describes which users or groups will be able to read files in this batch once it has been committed.
+              required:
+                - readUsers
+                - readGroups
+              properties:
+                readUsers:
+                  description: List of AD/B2C Object IDs for the individual users that can read this batch. This property must be present and the list will replace the existing list of read users.
+                  type: array
+                  items:
+                    type: string
+                readGroups:
+                  description: List of group names that can read this batch. This property must be present and the list will replace the existing list of read groups.
+                  type: array
+                  items:
+                    type: string
+      responses:
+        204:
+          description: No Content - the ACL has been modified.
+        400:
+          description: Bad request - Could be that the batch ID doesn't exist; the body content is in an invalid format; or both readUsers and readGroups are null or empty.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        410:
+          $ref: "#/components/responses/batchGone"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /batch/{batchId}/expiry:
+    put:
+      tags:
+        - UKHO Only
+      summary: Set the expiry date for the batch.
+      operationId: setExpiryDate
+      parameters:
+        - name: batchId
+          in: path
+          description: A Batch ID.
+          required: true
+          schema:
+            type: string
+            format: GUID
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                expiryDate:
+                  type: string
+                  format: date-time
+      responses:
+        204:
+          description: The expiry date for the batch has been set.
+        400:
+          description: Bad request - Could be that the batch ID doesn't exist or that the provided expiry date is invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        410:
+          $ref: "#/components/responses/batchGone"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /attributes:
+    get:
+      tags:
+        - public
+      summary: Get a list of batch attributes.
+      operationId: getBatchAttributesList
+      description: Get a list of the batch attributes that have been applied to batches that the user has access to and can be used to query the list of batches.
+      responses:
+        200:
+          description: Returns a list of the batch attributes that exist, in order of the ones applied to the most batches first.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              example:
+                [
+                  "Product Type",
+                  "Year",
+                  "Product ID",
+                  "Media Type",
+                  "Exchange Set Type",
+                  "Week Number",
+                  "S63 Version",
+                ]
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /attributes/search:
+    get:
+      tags:
+        - public
+      summary: Get a list of batch attributes and their values for a batch search.
+      operationId: getBatchAttributesAndValuesForSearch
+      description: |
+        Get a list of the batch attributes and their values that have been applied to batches for a batch search.
+      parameters:
+        - $ref: "#/components/parameters/batchAndFileFilter"
+        - $ref: "#/components/parameters/batchAttributeValueMaxCount"
+      responses:
+        200:
+          description: |
+            Returns a dictionary of the batch attributes and values that exist for the batches identified by the search.
+
+            Note : Some attributes (such as `TraceID`) are excluded from this list because they are likely to unique values for each batch. Also, the number of values returned for each attribute is limited to 25. If the attribute value list is truncated, the last entry will be `...`.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  searchBatchCount:
+                    type: integer
+                    description: Total number of batches that match the query.
+                  batchAttributes:
+                    type: object
+                    additionalProperties:
+                      type: array
+                      items:
+                        type: string
+              example:
+                {
+                  "searchBatchCount": 123,
+                  "batchAttributes":
+                    {
+                      "Product Type": ["AVCS", "ADP"],
+                      "Year": ["2021", "2022"],
+                      "Media Type": ["CD", "DVD", "Zip"],
+                      "Exchange Set Type": ["Base", "Update"],
+                      "Week Number":
+                        [
+                          "24",
+                          "25",
+                          "26",
+                          "27",
+                          "28",
+                          "29",
+                          "30",
+                          "31",
+                          "32",
+                          "33",
+                          "34",
+                          "35",
+                          "36",
+                          "37",
+                          "38",
+                          "39",
+                          "40",
+                          "41",
+                          "42",
+                          "43",
+                          "44",
+                          "45",
+                          "46",
+                          "47",
+                          "48",
+                          "...",
+                        ],
+                      "S63 Version": ["1.2"],
+                    }
+                }
+        400:
+          description: |
+            Bad request - there are one or more errors in the specified parameters, for example: a malformed query in the $filter.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+  /heartbeat:
+    get:
+      tags:
+        - public
+      description: |
+        Used for monitoring and service availability checks.
+      responses:
+        200:
+          description: The service is operating correctly.
+        503:
+          description: The service is not operating correctly.
+
+  /auth/client_credentials:
+    post:
+      tags:
+        - public
+      summary: Get token from AAD.
+      operationId: getTokenUsingClientCredentials
+      description: |
+        Returns a token direct from AAD using Client Credentials.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                client_id:
+                  type: string
+                  description: The application ID that's assigned to the distributor's app. This will be provided to the distributor when they register their application.
+                client_secret:
+                  type: string
+                  description: The client secret that was generated for the distributor's app when the app was registered. The client secret must be URL-encoded before being sent.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token_type:
+                    type: string
+                  expires_in:
+                    type: string
+                  ext_expires_in:
+                    type: string
+                  access_token:
+                    type: string
+              example: |
+                {
+                  "token_type": "Bearer",
+                  "expires_in": 3599,
+                  "ext_expires_in": 3599,
+                  "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Imwzc1EtNTBjQ0g0eEJWWkxIVEd3blNSNzY4MCJ9.eyJhdWQiOiI0ZTE1NGYyYi0wNWM2LTQwZDEtODdiNy0wYWYwNTI5ZTBhNTEiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZTkyYzk4MWItZDY4OS00Y2MzLTgyNDUtMGQ3MTBlMjQ2YmNhL3YyLjAiLCJpYXQiOjE2MzI0NzU1OTAsIm5iZiI6MTYzMjQ3NTU5MCwiZXhwIjoxNjMyNDc5NDkwLCJhaW8iOiJFMlpnWUdpZTJhSmhQT0ZDWTdQR3NxYUhaWi9tQXdBPSIsImF6cCI6IjJmMzJmNmY3LTFmMmYtNDNjZS1hZmQ3LWYzM2Y5M2NiN2U2MSIsImF6cGFjciI6IjEiLCJvaWQiOiJkNmY4ZDg0My0zZTY1LTQ5YTAtODdkNy0zMTBkMGNiM2UzOGUiLCJyaCI6IjAuQVNJQUc1Z3M2WW5XdzB5Q1JRMXhEaVJyeXZmMk1pOHZIODVEcjlmelA1UExmbUVpQUFBLiIsInN1YiI6ImQ2ZjhkODQzLTNlNjUtNDlhMC04N2Q3LTMxMGQwY2IzZTM4ZSIsInRpZCI6ImU5MmM5ODFiLWQ2ODktNGNjMy04MjQ1LTBkNzEwZTI0NmJjYSIsInV0aSI6IlREVmtmenZuS2txVEdRUXNEWjItQUEiLCJ2ZXIiOiIyLjAifQ.W-TB97v6D56UuPCstaSrfLFbc9gE6W1VHD5t0RLo_EK-1LuaTvQ0aqJtaYCRnXnd6RmMIIml3ckHxFL0lZlYUoSjszIMFkb1w0aH5SxD-GOfY-dktvGKdMVxqtyjJJg1IV7V3Dv1BYI24RnGPfcJG73-af7vcTRjE5KFeW_kOMVAfCAcZOV9dJ7BJULfEdHlK8ZFUb2hEzFkoORGdlrpNIJ7-QEhB9Kcnxa9QtA4z8lMtWESx-q17N88fmlaz87kEKEjX3pIP7k2l_y5BNtNAxK0h995pZ9hHNe4-UBH-xjvfuDa6IbCsZD1J1IW7AO1bXCjGGvc31PtJqEc5FRdQQ"
+                }
+        400:
+          description: Bad request - Request missing client_id and/or client_secret.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorDescription"
+              example:
+                {
+                  "correlationId": "184ef711-b039-4c24-b81a-89081d8f324c",
+                  "errors":
+                    [
+                      {
+                        "source": "request",
+                        "description": "request missing client_id and/or client_secret"
+                      }
+                    ]
+                }
+        401:
+          $ref: "#/components/responses/unauthorised"
+        403:
+          $ref: "#/components/responses/forbidden"
+        429:
+          $ref: "#/components/responses/tooManyRequests"
+
+components:
+  parameters:
+    paginationLimit:
+      name: limit
+      description: Specify the limit of the number of results returned in one page. Also known as page size. Optional parameter and defaults to 10 results per page. If specified, must be greater or equal to 1.
+      in: query
+      required: false
+      schema:
+        type: integer
+    paginationStart:
+      name: start
+      description: Specify the index of the first item returned in the results. Defaults to 0 (the first item). Used with pagination. If specified, must be greater than or equal to 0. If greater than the number of results, the service will return status code 400 (Bad Request).
+      in: query
+      required: false
+      schema:
+        type: integer
+    batchAndFileFilter:
+      name: $filter
+      description: |
+        The search `$filter` allows callers to filter the returned results loosely based on the OData 4.01 `$filter` syntax (See <http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_QueryOptions> for a full description of the OData query options).
+
+
+        ## User Attributes
+
+        User attributes can be used as part of the filter with the attribute name enclosed within `$batch( )` or `$file( )` e.g. `$batch(Attribute Name)` or `$file(Attribute Name)`. User Attribute names are not case sensitive, e.g. `$batch(Product)` and `$Batch(product)` are the same.
+
+        This allows the string operators below to be used, for example: `$filter=$batch(Product) eq 'AVCS'` or `$filter=endswith($file(Week Number), '/52')`
+
+        Batches and files within the batch have user attributes. For filtering, a batch is considered to have the combination of its own attributes and all the attributes of the files in that batch. Operators will then match on any of the attributes, so an operator could match on one or more of the batch's attributes, or any of the file's attributes.
+
+        A batch that has no instances of the attribute and no files with an instance of the attribute will be considered to have a null value for that attribute. Combined with the `null` literal, this can be used to test for the presence or absence of a user attribute.  (e.g. `$filter=$batch(Product) eq null` will return batches that don't have a `Product` attribute and `$filter=$file(Product) eq null` will return all batches for which files don't have a `Product` attribute.)
+
+        **Note**: user attribute values can only be compared with a literal value. It is not possible to compare one user attribute value with another user attribute value. e.g. `$filter=$batch(Product) eq $batch(Service)` or `$filter=$file(Product) eq $file(Service)` is an invalid filter and will return HTTP Status Code 400 - Bad Request.
+
+        Additionally, you can search for any batch user attribute that has a value that contains a search term. `$batchContains('searchTerm')` will look for any batch with any attribute that contains the 'searchTerm'. Whereas `$batch()` and `$file()` are string functions, i.e. they return the value of the attribute to then be compared with an operator below, `$batchContains()` is a boolean function and returns true or false. `$batchContains()` can be combined with boolean operators such as and and or.
+
+
+        ## System Attributes
+
+        System attribute names are not case sensitive. For example: `batchPublishedDate` is the same as `batchpublisheddate`.
+
+        The service supports queries on the following system attributes:
+
+        * `businessUnit` - Matches a string, e.g. `$filter=businessUnit eq 'ADDS'`. Partial matches are supported using the string operators below. e.g. `$filter=startswith(businessUnit,'Test')`.
+        * `batchPublishedDate` - The date the batch was published (committed) (not the individual files, or the initial batch created date). Only matches against a date literal or expression. Dates must be specified in full date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z. The system supports the comparison operators listed below e.g. `$filter=batchPublishedDate gt 2020-12-23T17:45:12Z`.
+        * `expiryDate` - Only matches against a date literal or expression. Dates must be specified in full date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z. The system supports the comparison operators listed below. e.g. `$filter=expiryDate lt 2020-01-05T19:56:48Z`.
+        * `filename` - Matches a string which is the filename of any of the files within a batch, e.g. `$filter=filename eq 'AUL37137.004'`. This will also support partial filename matches using the string operators below. e.g. `$filter=endswith(filename,'.iso')`.
+        * `filesize` - Matches an integer that is the the file size in bytes of any of the files in the batch. The match can be made using `eq` and `ne` operator as well as the comparison operators listed below. e.g. `$filter=fileSize gt 1000000` finds any batch that contains one or more files that is bigger than 1000000 bytes (1MB).
+        * `mimetype` - Matches a string that is the MIME Type of any of the files in the batch.  Partial matches can be made with the string operators listed below. e.g. `$filter=startswith(mimeType, 'text')` would match `text/json` and `text/plain` but not `application/json`.
+
+        The following system attributes have been considered and are **not** currently in scope:
+
+        * ~~`hash` - Search for this binary object?~~
+        * ~~`totalBatchSize` - Match against the sum of all the file sizes of the files in the batch? Much harder to translate to a SQL query, but possibly more useful to the users?~~
+
+        **Note**: System Attribute values can only be compared with a literal value. It is not possible to compare one System Attribute value with another System Attribute value. e.g. `$filter=batchedPublishedDate gt expiryDate` is an invalid filter and will return HTTP Status Code 400 - Bad Request.
+
+        ## Supported Operators
+
+        Comparison between two values of different types will fail (e.g. you can't compare a string value and a date, the query will return status code 400 (Bad Request)).
+
+        * And (`and`) - This binary operator can be used between two expressions and will return true if both the left and right expression are true.
+        * Or (`or`) - This binary operator can be used between two expressions and will return true if either the left expression or the right expression is true.
+        * Not (`not`) - The `not` operator returns true if the operand returns false, otherwise it returns false.  e.g. `$filter=not endswith($batch(Product),'ilk') or not endswith($file(Product),'ilk').
+        * Equals (`eq`) - Comparison of two values to see if they are the same. For string values, the comparison is case-insensitive, so `'Bob' eq 'BOB'` will return true. For Date-Time values, the comparison is exact so `2017-07-21T17:32:28Z eq 2017-07-21T17:32:29Z` will return false.
+        * Not Equals (`ne`) - Comparison of two values to see if they are different. For string values, the comparison is case-insensitive, so `'Bob' ne 'BOB'` will return false. For Date-Time values, the comparison is exact so `2017-07-21T17:32:28Z ne 2017-07-21T17:32:29Z` will return true.
+        * Comparison operators (only applies to numeric system attributes (i.e. `filesize`) or date system attributes (i.e. `batchPublishedDate` and `expiryDate`)).
+          * Greater Than (`gt`) e.g. `fileSize gt 1000000` or `batchPublishedDate gt 2020-12-23T17:45:12Z`.
+          * Greater Than or Equals (`ge`) e.g. `fileSize ge 1000000` or `batchPublishedDate ge 2020-12-23T17:45:12Z`.
+          * Less Than (`lt`) e.g. `fileSize lt 1000000` or `batchPublishedDate lt 2020-12-23T17:45:12Z`.
+          * Less Than or Equals (`le`) e.g. `fileSize le 1000000` or `batchPublishedDate le 2020-12-23T17:45:12Z`.
+        * String operators:
+          * Contains (`contains()`).
+          * Starts With (`startswith()`).
+          * Ends With (`endswith()`) - This operator returns true if the value of the attribute is a string and ends with the provided literal. e.g. `endswith(filename,'.iso')`.
+          
+
+
+        **Note**: the system does not support any other Functions or Arithmetic Operators.
+
+
+        ## Literal values
+
+        The system supports the following literal values:
+
+        * Null (`null`).
+        * True (`true`).
+        * False (`false`).
+        * Integer values (e.g. `-128`).
+        * String values (e.g. `'Say Hello,then go'`).
+        * String values with single quote (e.g. `'Rob O'Neil'`) - Replace 1 single quote with 2 single quotes to search a value having single quote. e.g. `'Rob O''Neil'`
+        * DateTimeOffset values (e.g. `2012-12-03T07:16:23Z`). Dates must be specified in the RFC 3339 format. They can contain a date-time offset, but will be converted to UTC before comparison.
+
+
+        ## Operator Precedence
+
+        Operators are listed by category in order of precedence from highest to lowest. Operators in the same category have equal precedence:
+
+          | Group           | Operator | Description           |
+          |-----------------|----------|-----------------------|
+          | Grouping        | ( )      | Precedence grouping   |
+          | Primary         | xxx( )   | Method Call           |
+          | Unary           | not      | Logical Negation      |
+          | Relational      | gt       | Greater Than          |
+          |                 | ge       | Greater Than or Equal |
+          |                 | lt       | Less Than             |
+          |                 | le       | Less Than or Equal    |
+          | Equality        | eq       | Equal                 |
+          |                 | ne       | Not Equal             |
+          | Conditional AND | and      | Logical And           |
+          | Conditional OR  | or       | Logical Or            |
+
+
+        The Grouping operator (open and close parenthesis `( )`) controls the evaluation order of an expression. The Grouping operator returns the expression grouped inside the parenthesis, e.g.:
+
+        ```
+          $filter=($batch(Product Type) eq 'AVCS') and ($batch(Week Number) eq '12' or $batch(Week Number) eq '13')
+        ```
+
+        ## Examples:
+
+          `$filter=$batch(Product Type) eq 'AVCS' and $batch(Week Number) eq '12' and batchPublishedDate gt 2020-10-21T00:00:00Z` - All AVCS files for Week Number 2020/12 created after 21 Oct 2020.
+
+          `$filter=batchPublishedDate gt 2020-10-21T00:00:00Z` - All files created after midnight on 21 Oct 2020.
+          
+          `$filter=expiryDate lt 2020-12-21T00:00:00Z` - All files due to expire before 21 Dec 2020.
+
+          `$filter=`$batchContains('AVCS')`
+
+      in: query
+      required: false
+      schema:
+        type: string
+    batchAttributeValueMaxCount:
+      name: maxAttributeValueCount
+      description: Optional. Specify the maximum number of batch attribute values to be returned in the result. If specified, must be greater than or equal to 1. If less than 1, the service will return status code 400 (Bad Request).
+      in: query
+      required: false
+      schema:
+        type: integer
+
+    range:
+      name: Range
+      in: header
+      description: |
+        Optional. Return file data only for the specified byte range.
+
+        ### Format 1: `bytes=startByte-`
+
+        This range will return bytes from the offset startByte through to the end of the file. For example, to specify a range encompassing all bytes after the first 256 bytes of a file, you can pass in the following header:
+
+        ```
+          Range: bytes=255-
+        ```
+
+        The `Content-Length` header in the response is equal to the number of bytes from the offset until the end of the file. Using the example range above for a file of 1,024 bytes in length, `Content-Length` would be 769.
+
+        If the offset is valid and does not exceed the file’s total length, the request will return status code 206 (Partial Content). If the offset is invalid and exceeds the file’s total length, the request will return status code 416 (Range Not Satisfiable).
+
+        ### Format 2: `bytes=startByte-endByte`
+
+        This range will return bytes from the offset startByte through to the endByte. For example, to specify a range encompassing the first 512 bytes of a file, you would pass in the following header:
+
+        ```
+          Range: bytes=0-511
+        ```
+
+        The `Content-Length` header in the response is equal to the number of bytes between each offset. Using the example range above for a file of 1,024 bytes in length, `Content-Length` would be 512.
+
+        If the offset is valid and does not exceed the file’s total length, the request will return status code 206 (Partial Content). If the offset is invalid and exceeds the file’s total length, the request will return status code 416 (Range Not Satisfiable).
+
+        See Microsoft documentation for more details on specifying the range header: <https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-the-range-header-for-file-service-operations>, the HTTP Range Requests specification: <https://tools.ietf.org/html/rfc7233> or Byte serving information <https://en.wikipedia.org/wiki/Byte_serving>.
+      required: false
+      schema:
+        type: string
+        format: bytes=startByte-endByte or bytes=startByte-
+
+  responses:
+    unauthorised:
+      description: Unauthorised - either you have not provided any credentials, or your credentials are not recognised.
+
+    forbidden:
+      description: Forbidden - you have been authorised, but you are not allowed to access this resource.
+
+    batchGone:
+      description: Gone - the specified batch has expired and is no longer available.
+
+    tooManyRequests:
+      description: You have sent too many requests in a given amount of time. Please back-off for the time in the Retry-After header (in seconds) and try again.
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Specifies the time you should wait in seconds before retrying.
+
+    partialContent:
+      description: Partial Content - The response is a partial content because a Range was specified for a part of the file.
+      headers:
+        Accept-Ranges:
+          description: The `Accept-Ranges` header indicates the that the service supports range requests for the target resource. This response will include `Accept-Ranges:bytes` to indicate that a partial range request is supported.
+          schema:
+            type: string
+        Content-Disposition:
+          description: The `Content-Disposition` header indicates that the response should be downloaded and saved, along with the suggested filename. e.g. `Content-Disposition:attachment; filename="filename.jpg"`.
+          schema:
+            type: string
+        Content-Range:
+          description: |
+            Describes the part of the file that is actually returned.
+
+            ### Syntax
+
+            ```
+              Content-Range: <unit> <range-start>-<range-end>/<size>
+              Content-Range: <unit> <range-start>-<range-end>/*
+              Content-Range: <unit> */<size>
+            ```
+
+            `<unit>` The unit in which ranges are specified. This will be `bytes`.
+
+            `<range-start>` An integer in bytes indicating the beginning of the request range.
+
+            `<range-end>` An integer in bytes indicating the end of the requested range.
+
+            `<size>` The total size of the file.
+
+            Example:
+
+            ```
+              Content-Range: bytes 200-1000/67589
+            ```
+          schema:
+            type: string
+        Content-Length:
+          description: The size of the content returned in bytes. This will be less than the full file size.
+          schema:
+            type: integer
+        Last-Modified:
+          description: Returns the date and time the file was last modified. The date is in RFC 1123 format.
+          schema:
+            type: string
+            format: date-time
+        Content-Type:
+          description: The content type specified for the file. If no content type was specified, the default content type is `application/octet-stream`.
+          schema:
+            type: string
+            format: MIME
+      content:
+        "*/*":
+          schema:
+            type: string
+            format: binary
+    redirect:
+      description: |
+        Temporary Redirect - the file should be downloaded from the URL provided in the `Location` header.
+
+        For reasons of download performance, when downloading a large file the client will be redirected to a direct/accelerated URL. The URL may include a temporary access token. The request to the URL should be a `GET` request with the full URL including any query parameters. No additional headers (including authorize headers) will be required.
+
+        Note - the redirect URL is likely to have a time and/or IP address limited access token attached to it, so should not be stored.
+      headers:
+        Location:
+          description: The absolute URL the file should be downloaded from, including any access tokens required.
+          schema:
+            type: string
+            format: URL
+
+  schemas:
+    exceptionDescription:
+      type: object
+      properties:
+        correlationId:
+          type: string
+        message:
+          type: string
+
+    errorDescription:
+      type: object
+      properties:
+        correlationId:
+          type: string
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/fieldError"
+
+    fieldError:
+      type: object
+      properties:
+        source:
+          type: string
+        description:
+          type: string
+
+    href:
+      type: string
+      format: uri
+    link:
+      type: object
+      properties:
+        href:
+          $ref: "#/components/schemas/href"
+
+    _links:
+      description: Links, usually describing links to next and previous pages in a paged result.
+      type: object
+      properties:
+        self:
+          description: Link to this page of the results.
+          $ref: "#/components/schemas/link"
+        first:
+          description: Link to the first page of the results. Will be the same as self if this is the first page.
+          $ref: "#/components/schemas/link"
+        previous:
+          description: Link to the previous page of results if there are any.
+          $ref: "#/components/schemas/link"
+        next:
+          description: Link to the next page of results if there are any.
+          $ref: "#/components/schemas/link"
+        last:
+          description: Link to the last page of results if there are any.
+          $ref: "#/components/schemas/link"
+
+    batchDetails:
+      description: Object representing the details of a batch.
+      type: object
+      properties:
+        batchId:
+          type: string
+          format: GUID
+        status:
+          type: string
+          enum: [Incomplete, CommitInProgress, Committed, Rolledback, Failed]
+        allFilesZipSize:
+          type: integer
+        attributes:
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+        businessUnit:
+          type: string
+        batchPublishedDate:
+          type: string
+          format: date-time
+        expiryDate:
+          type: string
+          format: date-time
+        isAllFilesZipAvailable:
+          description: Indicates if the zip of all files in the batch is available. See "#/paths/batch/{batchId}/files"
+          type: boolean
+        files:
+          type: array
+          items:
+            type: object
+            properties:
+              filename:
+                type: string
+              fileSize:
+                type: integer
+              mimeType:
+                type: string
+                description: The MIME content type of the file.
+              hash:
+                type: string
+                format: Base64
+                description: MD5 hash of the file content.
+              attributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+              links:
+                type: object
+                description: Contains links to the relevant APIs for this file.
+                properties:
+                  get:
+                    $ref: "#/components/schemas/link"
+
+    cloudEvent:
+      description: For the full spec, see https://github.com/cloudevents/spec/blob/v1.0/spec.md
+      externalDocs:
+        description: Event publishing based on Cloud Events.
+        url: https://github.com/cloudevents/spec/blob/v1.0/spec.md
+      required:
+        - id
+        - source
+        - specversion
+        - type
+      type: object
+      properties:
+        id:
+          type: string
+          description: Identifies the event. Producers MUST ensure that source + id is unique for each distinct event. If a duplicate event is re-sent (e.g. due to a network error) it MAY have the same id. Consumers MAY assume that events with identical source and id are duplicates. Examples include an event counter maintained by the producer or A UUID.
+        source:
+          type: string
+          format: uri
+          description: |
+            Identifies the context in which an event happened. Often this will include information such as the type of the event source, the organisation publishing the event or the process that produced the event. The exact syntax and semantics behind the data encoded in the URI is defined by the event producer.
+
+            Producers MUST ensure that source + id is unique for each distinct event.
+
+            An application MAY assign a unique source to each distinct producer, which makes it easy to produce unique IDs since no other producer will have the same source. The application MAY use UUIDs, URNs, DNS authorities or an application-specific scheme to create unique source identifiers.
+
+            A source MAY include more than one producer. In that case the producers MUST collaborate to ensure that source + id is unique for each distinct event.
+
+            Constraints
+              * REQUIRED
+              * MUST be a non-empty URI-reference
+              * An absolute URI is RECOMMENDED
+
+            examples
+              * Internet-wide unique URI with a DNS authority.
+              * https://github.com/cloudevents
+              * mailto:cncf-wg-serverless@lists.cncf.io
+              * Universally-unique URN with a UUID:
+              * urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66
+              * Application-specific identifiers
+              * /cloudevents/spec/pull/123
+              * /sensors/tn-1234567/alerts
+              * 1-555-123-4567
+        specversion:
+          type: string
+          description: The version of the CloudEvents specification which the event uses. This enables the interpretation of the context. Compliant event producers MUST use a value of `1.0` when referring to this version of the specification.
+        "type":
+          type: string
+          description: |
+            This attribute contains a value describing the type of event related to the originating occurrence. Often this attribute is used for routing, observability or policy enforcement. The format of this is producer defined and might include information such as the version of the type - see Versioning of Attributes in the Primer for more information.
+
+            Constraints
+              * REQUIRED
+              * MUST be a non-empty string
+              * SHOULD be prefixed with a reverse-DNS name (uk.gov.ukho). The prefixed domain dictates the organisation which defines the semantics of this event type.
+
+            Examples
+              * uk.gov.ukho.encpublishing.newedition
+              * uk.gov.ukho.ordering.neworder
+        datacontenttype:
+          type: string
+          format: RFC 2046
+          description: |
+            Content type of data value. This attribute enables data to carry any type of content, whereby format and encoding might differ from that of the chosen event format. For example, an event rendered using the JSON envelope format might carry an XML payload in data, and the consumer is informed by this attribute being set to "application/xml". The rules for how data content is rendered for different datacontenttype values are defined in the event format specifications; for example, the JSON event format defines the relationship in section 3.1.
+            For some binary mode protocol bindings, this field is directly mapped to the respective protocol's content-type metadata property. Normative rules for the binary mode and the content-type metadata mapping can be found in the respective protocol.
+            In some event formats the datacontenttype attribute MAY be omitted. For example, if a JSON format event has no datacontenttype attribute, then it is implied that the data is a JSON value conforming to the "application/json" media type. In other words; a JSON-format event with no datacontenttype is exactly equivalent to one with datacontenttype="application/json".
+            When translating an event message with no datacontenttype attribute to a different format or protocol binding, the target datacontenttype SHOULD be set explicitly to the implied datacontenttype of the source.
+                        
+            Constraints
+              * If present, MUST adhere to the format specified in RFC 2046 https://tools.ietf.org/html/rfc2046.
+
+            Examples
+              * For Media Type examples see IANA Media Types http://www.iana.org/assignments/media-types/media-types.xhtml.
+        dataschema:
+          type: string
+          format: URI
+          description: |
+            Identifies the schema that data adheres to. Incompatible changes to the schema SHOULD be reflected by a different URI. See Versioning of Attributes in the Primer for more information.
+
+            Constraints
+              * If present, MUST be a non-empty URI.
+        subject:
+          type: string
+          description: |
+            This describes the subject of the event in the context of the event producer (identified by source). In publish-subscribe scenarios, a subscriber will typically subscribe to events emitted by a source, but the source identifier alone might not be sufficient as a qualifier for any specific event if the source context has internal sub-structure.
+
+            Identifying the subject of the event in context metadata (opposed to only in the data payload) is particularly helpful in generic subscription filtering scenarios where middleware is unable to interpret the data content. In the above example, the subscriber might only be interested in blobs with names ending with '.jpg' or '.jpeg' and the subject attribute allows for constructing a simple and efficient string-suffix filter for that subset of events.
+
+            Constraints
+              * If present, MUST be a non-empty string.
+
+            Example
+              * A subscriber might register interest for when new blobs are created inside a blob-storage container. In this case, the event source identifies the subscription scope (storage container), the type identifies the "blob created" event, and the id uniquely identifies the event instance to distinguish separate occurrences of a same-named blob having been created; the name of the newly created blob is carried in subject.
+              
+                source: https://example.com/storage/tenant/container
+                subject: mynewfile.jpg
+        time:
+          type: string
+          format: date-time
+          description: |
+            Timestamp of when the occurrence happened. If the time of the occurrence cannot be determined then this attribute MAY be set to some other time (such as the current time) by the CloudEvents producer, however all producers for the same source MUST be consistent in this respect. In other words, either they all use the actual time of the occurrence or they all use the same algorithm to determine the value used.
+        data:
+          type: object
+          description: |
+            The event payload. This specification does not place any restriction on the type of this information. It is encoded into a media format which is specified by the datacontenttype attribute (e.g. application/json), and adheres to the dataschema format when those respective attributes are present.
+
+            The `uk.gov.UKHO.FileShareService.NewFilesPublished.v1` event payload is described by "#/components/schemas/newBatchNotificationPayload".
+    newBatchNotificationPayload:
+      type: object
+      description: |
+        The payload of a new batch notification event that is carried within the `data` property of the cloudEvent. The CloudEvent will have a `type` property with value: `uk.gov.UKHO.FileShareService.NewFilesPublished.v1`.
+      properties:
+        batchId:
+          type: string
+          format: GUID
+        links:
+          type: object
+          description: Contains links to the relevant APIs for this batch.
+          properties:
+            batchStatus:
+              $ref: "#/components/schemas/link"
+            batchDetails:
+              $ref: "#/components/schemas/link"
+        attributes:
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+        businessUnit:
+          type: string
+        batchPublishedDate:
+          type: string
+          format: date-time
+        files:
+          type: array
+          description: Lists the files included in the batch.
+          items:
+            type: object
+            properties:
+              filename:
+                type: string
+              fileSize:
+                description: The size of the file in bytes.
+                type: integer
+              mimeType:
+                type: string
+                description: The MIME content type of the file.
+              hash:
+                type: string
+                format: Base64
+                description: MD5 hash of the file content.
+              attributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+              links:
+                type: object
+                description: Contains links to the relevant APIs for this file. (Note - at present this can only be a place holder as there are no APIs for files yet. In a future implementation this will contain links to allow downloading of the file.)
+                properties:
+                  get:
+                    $ref: "#/components/schemas/link"
+
+  securitySchemes:
+    jwtBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/deployment/salesCatalogue_ExchangeSetService_API_definition_v1.10.yaml
+++ b/deployment/salesCatalogue_ExchangeSetService_API_definition_v1.10.yaml
@@ -1,0 +1,1063 @@
+openapi: "3.0.0"
+info:
+  version: "1.10"
+  title: Sales Catalogue Service API
+  description: |
+    This API is for Sales Catalogue Service
+  contact:
+    email: teamcalypso@ukho.gov.uk
+
+servers:
+  - url: https://salescatalogue.ukho.gov.uk
+security:
+  - jwtBearerAuth: []
+
+paths:
+  /v1/productData/{productType}/products:
+    get:
+      summary: Get all releasable changes to products since a date
+      operationId: getProducts
+      tags:
+        - Products v1
+      parameters:
+        - $ref: "#/components/parameters/productType"
+        - $ref: "#/components/parameters/sinceDateTime"
+
+      responses:
+        "200":
+          description: A JSON body of product objects
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/productResponse"
+
+        "304":
+          $ref: "#/components/responses/NotModifiedResponse"
+
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+
+        "401":
+          $ref: "#/components/responses/UnauthorisedResponse"
+
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
+
+  /v1/productData/{productType}/products/productIdentifiers:
+    post:
+      summary: Get the latest baseline, releasable versions for requested products
+
+      operationId: postProductIdentifiers
+      tags:
+        - Products v1
+      parameters:
+        - $ref: "#/components/parameters/productType"
+
+      requestBody:
+        description: |
+          The JSON body containing an array of product identifiers.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/productIdentifiers"
+
+      responses:
+        "200":
+          description: A JSON body of product objects
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/productResponse"
+
+        "304":
+          $ref: "#/components/responses/NotModifiedResponse"
+
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+
+        "401":
+          $ref: "#/components/responses/UnauthorisedResponse"
+
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaTypeResponse"
+
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
+
+  /v1/productData/{productType}/products/productVersions:
+    post:
+      summary: Get the latest baseline, releasable versions for requested products since a specified version
+
+      operationId: postProductVersions
+      tags:
+        - Products v1
+      parameters:
+        - $ref: "#/components/parameters/productType"
+
+      requestBody:
+        description: |
+          The JSON body containing product versions.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/productVersions"
+
+      responses:
+        "200":
+          description: A JSON body of product objects
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/productResponse"
+
+        "304":
+          $ref: "#/components/responses/NotModifiedResponse"
+
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+
+        "401":
+          $ref: "#/components/responses/UnauthorisedResponse"
+
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaTypeResponse"
+
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
+
+  /v1/productData/{productType}/catalogue/{catalogueType}:
+    get:
+      summary: Get the data for a catalogue
+      operationId: getCatalogue
+      tags:
+        - Catalogue v1
+
+      parameters:
+        - $ref: "#/components/parameters/productType"
+        - $ref: "#/components/parameters/catalogueType"
+        - $ref: "#/components/parameters/If-Modified-Since"
+
+      responses:
+        "200":
+          description: A JSON body of data for the requested catalogue
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/essData"
+                  - $ref: "#/components/schemas/products"
+
+        "304":
+          $ref: "#/components/responses/NotModifiedResponse"
+
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+
+        "401":
+          $ref: "#/components/responses/UnauthorisedResponse"
+
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaTypeResponse"
+
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
+
+  /v2/products/s100/productNames:
+    post:
+      summary: Get the latest baseline, releasable versions for requested products
+
+      operationId: getS100ProductNames
+      tags:
+        - Products v2
+
+      requestBody:
+        description: |
+          The JSON body containing product names
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/s100ProductNames"
+
+      responses:
+        "200":
+          description: A JSON body of product objects
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/s100ProductResponse"
+              examples:
+                example1:
+                  summary: Example response for requested product names
+                  value:
+                    productCounts:
+                      requestedProductCount: 3
+                      returnedProductCount: 2
+                      requestedProductsAlreadyUpToDateCount: 1
+                      requestedProductsNotReturned: []
+                    products:
+                      - editionNumber: 34
+                        productName: "101GB01496A"
+                        updateNumbers:
+                          - 0
+                          - 1
+                        dates:
+                          - issueDate: "2022-06-10T00:00:00.0000000Z"
+                            updateApplicationDate: "2022-06-10T00:00:00.0000000Z"
+                            updateNumber: 0
+                          - issueDate: "2024-07-09T00:00:00.0000000Z"
+                            updateNumber: 1
+                        fileSize: 214136
+                      - editionNumber: 1
+                        productName: "101GB01569B"
+                        updateNumbers:
+                          - 0
+                        dates:
+                          - issueDate: "2024-07-09T00:00:00.0000000Z"
+                            updateApplicationDate: "2024-07-09T00:00:00.0000000Z"
+                            updateNumber: 0
+                        fileSize: 9888
+
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+
+        "401":
+          $ref: "#/components/responses/UnauthorisedResponse"
+
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaTypeResponse"
+
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
+
+  /v2/products/s100/productVersions:
+    post:
+      summary: Get the latest baseline, releasable versions for requested products since a specified version
+
+      operationId: getS100ProductVersions
+      tags:
+        - Products v2
+
+      requestBody:
+        description: |
+          The JSON body containing product versions
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/s100ProductVersions"
+
+      responses:
+        "200":
+          description: A JSON body of product objects
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/s100ProductResponse"
+
+        "304":
+          description: Not modified. The 304 response indicates that the requested product versions have not been modified. This response is returned if all the products in the request are already at the latest edition and update numbers
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+
+        "401":
+          $ref: "#/components/responses/UnauthorisedResponse"
+
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaTypeResponse"
+
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
+
+  /v2/products/s100/updatesSince:
+    get:
+      summary: Get all releasable changes to products since a date
+      operationId: getS100Products
+      tags:
+        - Products v2
+      parameters:
+        - $ref: "#/components/parameters/sinceDateTime"
+        - $ref: "#/components/parameters/s100ProductIdentifier"
+
+      responses:
+        "200":
+          description: A JSON body of product objects
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/s100ProductResponse"
+
+        "304":
+          description: Not modified. The 304 response indicates that there has not been any updated after the requested sinceDateTime.
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+
+        "401":
+          $ref: "#/components/responses/UnauthorisedResponse"
+
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaTypeResponse"
+
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
+
+  /v2/catalogues/s100/basic:
+    get:
+      summary: Retrieve the latest S-100 basic catalogue data, including product names, editions, updates, and statuses
+      operationId: getS100Catalogue
+      tags:
+        - Catalogue v2
+
+      parameters:
+        - $ref: "#/components/parameters/If-Modified-Since"
+
+      responses:
+        "200":
+          description: A JSON body of data for the requested catalogue
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+          content:
+            application/json:
+              examples:
+                example1:
+                  summary: Example with new edition
+                  value:
+                    - productName: "101GB020111"
+                      latestEditionNumber: 3
+                      latestUpdateNumber: 0
+                      status:
+                        statusName: "newEdition"
+                        statusDate: "2024-12-04T05:43:41Z"
+                    - productName: "101GB010130"
+                      latestEditionNumber: 1
+                      latestUpdateNumber: 0
+                      status:
+                        statusName: "newDataset"
+                        statusDate: "2024-12-08T05:43:41Z"
+              schema:
+                $ref: "#/components/schemas/s100BasicCatalogue"
+
+        "304":
+          description: Not modified. The 304 response indicates that there has not been any updates to the catalogue after the requested If-Modified-Since.
+          headers:
+            Last-Modified:
+              schema:
+                $ref: "#/components/schemas/Last-Modified"
+
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+
+        "401":
+          $ref: "#/components/responses/UnauthorisedResponse"
+
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaTypeResponse"
+
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
+
+components:
+  ################################################################################
+  #                              Parameter Definitions                           #
+  ################################################################################
+
+  parameters:
+    productType:
+      in: path
+      name: productType
+      required: true
+      description: |
+        The type of product
+      schema:
+        type: string
+      example: encS57, arcs, paperchart
+
+    s100ProductIdentifier:
+      in: query
+      name: productIdentifier
+      description: |
+        The specification of the S-100 standard that we are interested in.
+      schema:
+        type: string
+      example: "s101"
+
+    sinceDateTime:
+      in: query
+      name: sinceDateTime
+      required: true
+      description: |
+        The date and time from which changes are requested. Any changes since the date will be returned.
+      schema:
+        type: string
+        format: date-time
+      example: "2019-10-27T00:00:00Z"
+
+    If-Modified-Since:
+      in: header
+      name: If-Modified-Since
+      required: false
+      description: |
+        The date and time since items have changed.
+      schema:
+        type: string
+        format: date-time
+      example: "2019-10-27T00:00:00Z"
+
+    catalogueType:
+      in: path
+      name: catalogueType
+      required: true
+      description: |
+        The type of catalogue data requested
+      schema:
+        type: string
+      example: essData, avcsCatalogue
+
+  ################################################################################
+  #                              Object Definitions                              #
+  ################################################################################
+
+  schemas:
+    ####################################
+    #      Request Objects      #
+    ####################################
+
+    productIdentifiers:
+      type: array
+      items:
+        type: string
+      example: ["US2ARCGD", "CA379151", "DE110000"]
+
+    s100ProductNames:
+      type: array
+      items:
+        type: string
+      example: ["101GB01569B", "101GB01496A", "101GB01476C"]
+
+    productVersions:
+      type: array
+      items:
+        type: object
+        properties:
+          productName:
+            type: string
+            description: The unique product identifiers
+          editionNumber:
+            type: integer
+            description: The edition number
+          updateNumber:
+            type: integer
+            description: The update number
+      example:
+        [
+          { "productName": "AU895561", "editionNumber": 4, "updateNumber": 1 },
+          { "productName": "AU895562", "editionNumber": 2, "updateNumber": 1 },
+        ]
+
+    s100ProductVersions:
+      description: "An array of S-100 product version objects, each representing a unique product name, edition number, and update number for the S-100 standard."
+      type: array
+      items:
+        type: object
+        properties:
+          productName:
+            type: string
+            description: The unique product name
+          editionNumber:
+            type: integer
+            description: The edition number
+          updateNumber:
+            type: integer
+            description: The update number
+      example:
+        [
+          {
+            "productName": "101GB40079ABCDEFG",
+            "editionNumber": 1,
+            "updateNumber": 1,
+          },
+          {
+            "productName": "102NO32904820801012",
+            "editionNumber": 2,
+            "updateNumber": 2,
+          },
+          {
+            "productName": "104US00_CHES_TYPE1_20210630_0600",
+            "editionNumber": 3,
+            "updateNumber": 3,
+          },
+          {
+            "productName": "111US00_ches_dcf8_20190703T00Z",
+            "editionNumber": 4,
+            "updateNumber": 4,
+          },
+        ]
+
+    ####################################
+    #      Response Objects      #
+    ####################################
+
+    productResponse:
+      type: object
+      properties:
+        products:
+          $ref: "#/components/schemas/products"
+        productCounts:
+          $ref: "#/components/schemas/productCounts"
+
+    s100ProductResponse:
+      type: object
+      properties:
+        productCounts:
+          $ref: "#/components/schemas/s100ProductCounts"
+        products:
+          $ref: "#/components/schemas/s100Products"
+
+    products:
+      type: array
+      items:
+        type: object
+        properties:
+          productName:
+            type: string
+            description: The unique product identifier
+          editionNumber:
+            type: integer
+            description: The edition number
+          updateNumbers:
+            type: array
+            description: an array of update numbers
+            items:
+              type: integer
+              description: The update number
+              example: 0
+          dates:
+            type: array
+            items:
+              type: object
+              description: issue and update dates
+              properties:
+                updateNumber:
+                  type: integer
+                  description: The update number, including update 0 if relevant
+                updateApplicationDate:
+                  type: string
+                  format: date-time
+                  description: |
+                    The update application date for the catalog, corresponding to the 031 UADT data field.
+                    - Represents the base cell issue date or, for re-issues, the issue date of the previous update.
+                    - This field is optional and may be omitted if not relevant.
+                  example: "2019-10-27T00:00:00Z"
+                issueDate:
+                  type: string
+                  format: date-time
+                  description: |
+                    The issue date for the catalog.031 ISDT data field
+                  example: "2019-10-27T00:00:00Z"
+
+          cancellation:
+            type: object
+            description: The details of the cancellation, if one exists
+            properties:
+              editionNumber:
+                type: integer
+                description: The edition number of the cancellation, i.e. 0
+              updateNumber:
+                type: integer
+                description: The cancellation update number
+            example: { "editionNumber": 0, "updateNumber": 8 }
+          fileSize:
+            type: integer
+            description: the total file size in bytes of all the files for this product
+          bundle:
+            type: array
+            description: |
+              Collection of physical bundles that are associated with the latest update of this product
+            items:
+              type: object
+              properties:
+                bundleType:
+                  type: string
+                  description: |
+                    Media type of the bundle, which can be one of the following values:
+
+                    - DVD
+                  example: "DVD"
+                location:
+                  type: string
+                  description: |
+                    DVDs: This field is divided into two subfields delimited by a “;” (semi colon). 
+                    The first subfield contains the media number ID and the second the exchange set number. 
+                    The Media ID is designated with a “M” followed by a number.
+
+                    Examples: 
+                    - base cell: "M1;B3", 
+                    - updates: "M2;U1"
+                  example: "M1;B3"
+
+    s100Products:
+      type: array
+      items:
+        type: object
+        properties:
+          productName:
+            type: string
+            description: The unique product names
+            example: "101GB40079ABCDEFG"
+          editionNumber:
+            type: integer
+            description: The edition number
+          updateNumbers:
+            type: array
+            description: An array of update numbers
+            items:
+              type: integer
+              description: The update number, including update 0 if relevant
+          dates:
+            type: array
+            items:
+              type: object
+              description: An array of objects representing the issue and update dates for a product. Each entry corresponds to a specific update number.
+              properties:
+                updateNumber:
+                  type: integer
+                  description: The update number
+                updateApplicationDate:
+                  type: string
+                  format: date-time
+                  description: |
+                    The update application date for the catalog, corresponding to the 031 UADT data field.
+                    - Represents the base cell issue date or, for re-issues, the issue date of the previous update.
+                    - This field is optional and will only be returned displayed only when the status is "newEdition," "newDataset," or "reissue".
+                  example: "2019-10-27T00:00:00Z"
+                issueDate:
+                  type: string
+                  format: date-time
+                  description: |
+                    The issue date for the catalog.031 ISDT data field
+                  example: "2019-10-27T00:00:00Z"
+
+          cancellation:
+            type: object
+            description: The details of the cancellation, if one exists
+            properties:
+              editionNumber:
+                type: integer
+                description: The edition number of the cancellation.
+                example: 0
+              updateNumber:
+                type: integer
+                description: The cancellation update number
+            example: { "editionNumber": 0, "updateNumber": 8 }
+          fileSize:
+            type: integer
+            description: The total file size in bytes of all the files for this product
+
+    productCounts:
+      type: object
+      properties:
+        requestedProductCount:
+          type: integer
+          description: number of products explicitly requested.
+        returnedProductCount:
+          type: integer
+          description: number of products that have data included in the produced exchange set.
+        requestedProductsAlreadyUpToDateCount:
+          type: integer
+          description: The count of requested products that are already up to date.
+        requestedProductsNotReturned:
+          type: array
+          description: |
+            Where a requested product is not included in the response, the product will be listed in the requestedProductNotReturned portion of the response along with a reason. The reason will be one of:
+               * productWithdrawn (the product has been withdrawn from the AVCS service)
+               * invalidProduct (the product is not part of the AVCS Service, i.e. is an invalid or unknown ENC)
+               * noDataAvailableForCancelledProduct (the product has been cancelled, and is beyond the retention period. Cancelled cells within the retention period will be returned with the cancellation data in the exchange set)
+               * duplicateProduct (the product was included in the request more than once)
+          items:
+            type: object
+            required:
+              - "productName"
+              - "reason"
+            properties:
+              productName:
+                type: string
+              reason:
+                type: string
+                enum:
+                  [
+                    productWithdrawn,
+                    invalidProduct,
+                    noDataAvailableForCancelledProduct,
+                    duplicateProduct,
+                  ]
+
+    s100ProductCounts:
+      description: Represents the count of S-100 products in the exchange set service.
+      type: object
+      properties:
+        requestedProductCount:
+          type: integer
+          description: The number of products explicitly requested
+          example: 3
+        returnedProductCount:
+          type: integer
+          description: The number of products that have data included in the produced exchange set
+          example: 2
+        requestedProductsAlreadyUpToDateCount:
+          type: integer
+          description: The number of products that are already up to date
+          example: 1
+        requestedProductsNotReturned:
+          type: array
+          description: |
+            Where a requested product is not included in the return, the product will be listed in the requestedProductNotReturned portion of the response along with a reason. The reason will be one of:
+               * productWithdrawn (the product has been withdrawn )
+               * invalidProduct (the product is not part of the S-100 Service, i.e. is an invalid or unknown dataset)
+               * noDataAvailableForCancelledProduct (the product has been cancelled, and is beyond the retention period. Cancelled cells within the retention period will be returned with the cancellation data in the exchange set)
+               * duplicateProduct (the product was included in the request more than once)
+          items:
+            type: object
+            required:
+              - "productName"
+              - "reason"
+            properties:
+              productName:
+                type: string
+                example: "102NO32904820801012"
+              reason:
+                type: string
+                enum:
+                  - productWithdrawn
+                  - invalidProduct
+                  - noDataAvailableForCancelledProduct
+                  - duplicateProduct
+
+    essData:
+      type: array
+      items:
+        type: object
+        properties:
+          productName:
+            type: string
+            description: |
+              Name of product
+            example: "GB202400"
+          baseCellIssueDate:
+            type: string
+            format: date
+            description: |
+              The date that a base cell (new cell, new edition or re-issue) was issued.
+            example: "2005-02-22"
+          baseCellEditionNumber:
+            type: integer
+            description: The edition number
+          issueDateLatestUpdate:
+            type: string
+            format: date
+            description: |
+              The date that the latest update was issued.
+            example: "2005-02-22"
+          latestUpdateNumber:
+            type: integer
+            description: |
+              The update number of the latest update.  Blank when no update.
+            example: 4
+          fileSize:
+            type: integer
+            description: |
+              The total file size in kilobytes for all files issued for the product.
+              Currently blank.
+          cellLimitSouthernmostLatitude:
+            type: number
+            description: |
+              Southernmost latitude of data coverage in the ENC product.
+            example: 49.898773299986
+          cellLimitWesternmostLatitude:
+            type: number
+            description: |
+              Westernmost longitude of data coverage in the ENC product.
+            example: -1.927277300003
+          cellLimitNorthernmostLatitude:
+            type: number
+            description: |
+              Northernmost latitude of data coverage in the ENC product.
+            example: 50.922828000014
+          cellLimitEasternmostLatitude:
+            type: number
+            description: |
+              Easternmost longitude of data coverage in the ENC product
+            example: 0.000166700008
+          dataCoverageCoordinates:
+            type: array
+            items:
+              type: object
+              properties:
+                latitude:
+                  type: number
+                longitude:
+                  type: number
+            description: |
+              Optional. Currently blank.
+              10 coordinate pairs can be supplied to indicate the data coverage within the ENC cell. It will be provided as repeating Y-coordinate and X-coordinate pairs.
+          compression:
+            type: boolean
+            description: |
+              Indicator of compression of dataset.
+            example: true
+          encryption:
+            type: boolean
+            description: |
+              Indicator of encryption of dataset.
+            example: true
+          baseCellUpdateNumber:
+            type: integer
+            description: |
+              The update number current at the time of a cell reissue. If a cell edition does not have a re-issue then this field is blank or zero filled
+            example: 1
+          lastUpdateNumberPreviousEdition:
+            type: integer
+            description: |
+              Last update number of previous edition, if previous editions are available.  
+              Currently blank.
+          baseCellLocation:
+            type: string
+            description: |
+              DVDs This field is divided into two subfields delimited by a “;” (semi colon). The first subfield contains the media number ID and the second the exchange set number. The Media ID is designated with a “M” followed by a number.
+            example: base cell “M1;B3”, Updates “M2;U1”
+          cancelledCellReplacements:
+            type: array
+            items:
+              type: string
+            description: |
+              List of replacement cells, if relevant, when a cell is cancelled.  Semi-colon separated.
+            example: ["FR312345", "FR323456"]
+          issueDatePreviousUpdate:
+            type: string
+            format: date
+            description: |
+              The date that the previous update was issued when the current update is a re-issue.
+            example: "2005-02-22"
+          cancelledEditionNumber:
+            type: integer
+            description: |
+              For a cancellation, this is the latest edition number prior to the cancellation update
+            example: 5
+
+    s100BasicCatalogue:
+      description: "An array of S-100 basic catalogue entries, each providing the product name, its latest edition number, latest update number, and current status."
+      type: array
+      items:
+        type: object
+        properties:
+          productName:
+            type: string
+            description: Name of the product, including details such as geographic coverage or specific identifiers.
+            example: "101GB40079ABCDEFG"
+          latestEditionNumber:
+            type: integer
+            description: The latest edition number of the product.
+            example: 4
+          latestUpdateNumber:
+            type: integer
+            description: The latest update number of the product.
+            example: 4
+          status:
+            type: object
+            properties:
+              statusName:
+                type: string
+                description: Current status of the product. Can be one of `newEdition`, `update`, or `cancellation`.
+                example: "newEdition"
+                enum:
+                  - newEdition
+                  - update
+                  - cancellation
+                  - newDataset 
+              statusDate:
+                type: string
+                format: date-time
+                description: The date and time when the status was assigned.
+                example: "2024-07-20T19:20:30.45+01:00"
+
+    Last-Modified:
+      type: string
+      format: date-time
+      example: "2019-10-27T00:00:00Z"
+
+    ####################################
+    #      Error Response Objects      #
+    ####################################
+
+    DefaultErrorResponse:
+      type: object
+      title: Error
+      properties:
+        correlationId:
+          type: string
+        detail:
+          type: string
+
+    unsupportedMediaTypeError:
+      type: object
+      title: RFC 7807
+      properties:
+        type:
+          type: string
+          example: "https://tools.ietf.org/html/rfc9110#section-15.5.16"
+        title:
+          type: string
+          example: "Unsupported Media Type"
+        status:
+          type: integer
+          example: 415
+        traceId:
+          type: string
+          example: "00-495f6c643d57a14da134952727dffbcc-fee4ec71f2fc8a62-01"
+
+    errorDescription:
+      type: object
+      properties:
+        correlationId:
+          type: string
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/fieldError"
+
+    fieldError:
+      type: object
+      properties:
+        source:
+          type: string
+        description:
+          type: string
+
+  ####################################
+  #      Error Responses             #
+  ####################################
+
+  responses:
+    UnauthorisedResponse:
+      description: Unauthorised.
+    ForbiddenResponse:
+      description: Forbidden.
+    NotFoundResponse:
+      description: Not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DefaultErrorResponse"
+    InternalServerErrorResponse:
+      description: Internal Server Error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DefaultErrorResponse"
+    BadRequestResponse:
+      description: Bad request.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/errorDescription"
+    NotModifiedResponse:
+      description: Not modified.
+      headers:
+        Last-Modified:
+          schema:
+            $ref: "#/components/schemas/Last-Modified"
+    UnsupportedMediaTypeResponse:
+      description: The request entity has a media type which the server or resource does not support.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/unsupportedMediaTypeError"
+
+  ####################################
+  #      Security Objects      #
+  ####################################
+
+  securitySchemes:
+    jwtBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/src/UKHO.ADDS.Clients.Common/MiddlewareExtensions/KiotaMiddlewareExtensions.cs
+++ b/src/UKHO.ADDS.Clients.Common/MiddlewareExtensions/KiotaMiddlewareExtensions.cs
@@ -47,13 +47,33 @@ namespace UKHO.ADDS.Clients.Common.MiddlewareExtensions
         }
 
         /// <summary>
+        /// Registers a Kiota client in the service collection, including its configured HTTP client and factory.
+        /// </summary>
+        /// <typeparam name="TClient">The Kiota client type to register.</typeparam>
+        /// <param name="services">The service collection to register the client with.</param>
+        /// <param name="endpointConfigKey">The configuration key for the endpoint URL.</param>
+        /// <param name="headers">Optional default headers to add to the HTTP client.</param>
+        public static void RegisterKiotaClient<TClient>(
+            this IServiceCollection services,
+            Func<IServiceProvider, Uri> uriFunc,
+            IDictionary<string, string>? headers = null)
+            where TClient : class
+        {
+            // Ensure Inspection Handler is configured to inspect response headers
+            var headersOption = new HeadersInspectionHandlerOption { InspectResponseHeaders = true };
+            services.AddSingleton(headersOption);
+            services.AddConfiguredHttpClient<TClient>(uriFunc, headers);
+            services.AddSingleton(sp => sp.GetRequiredService<ClientFactory>().GetClient<TClient>());
+        }
+
+        /// <summary>
         /// Attaches all registered Kiota middleware handlers to the HTTP client builder.
         /// </summary>
         /// <param name="builder">The HTTP client builder to attach handlers to.</param>
         /// <returns>The updated HTTP client builder.</returns>
         private static IHttpClientBuilder AttachKiotaHandlers(this IHttpClientBuilder builder)
         {
-            var kiotaHandlers = KiotaClientFactory.CreateDefaultHandlers([new HeadersInspectionHandlerOption() { InspectResponseHeaders = true}]);
+            var kiotaHandlers = KiotaClientFactory.CreateDefaultHandlers([new HeadersInspectionHandlerOption() { InspectResponseHeaders = true }]);
             foreach (var handler in kiotaHandlers)
             {
                 builder.AddHttpMessageHandler(() => handler);
@@ -92,6 +112,38 @@ namespace UKHO.ADDS.Clients.Common.MiddlewareExtensions
                 }
                 var logger = provider.GetRequiredService<ILogger<TClient>>();
                 logger.LogInformation("Configured HTTP client for " + typeof(TClient).Name + " with base address: " + endpoint);
+            }).AttachKiotaHandlers();
+        }
+
+        /// <summary>
+        /// Registers and configures an HTTP client for a specific Kiota client type using a configuration key for the endpoint.
+        /// </summary>
+        /// <typeparam name="TClient">The Kiota client type to register.</typeparam>
+        /// <param name="services">The service collection to register the HTTP client with.</param>
+        /// <param name="uri">The service URI</param>
+        /// <param name="headers">Optional default headers to add to the HTTP client.</param>
+        /// <returns>The HTTP client builder for further configuration.</returns>
+        public static IHttpClientBuilder AddConfiguredHttpClient<TClient>(
+            this IServiceCollection services,
+            Func<IServiceProvider, Uri> uriFunc,
+            IDictionary<string, string>? headers = null)
+            where TClient : class
+        {
+            return services.AddHttpClient<TClient>((provider, client) =>
+            {
+                var uri = uriFunc(provider);
+
+                client.BaseAddress = uri;
+
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        client.DefaultRequestHeaders.Add(header.Key, header.Value);
+                    }
+                }
+                var logger = provider.GetRequiredService<ILogger<TClient>>();
+                logger.LogInformation("Configured HTTP client for " + typeof(TClient).Name + " with base address: " + uri.AbsoluteUri);
             }).AttachKiotaHandlers();
         }
     }


### PR DESCRIPTION
This pull request introduces improvements to the Kiota client registration and generation process. The main changes include enhancements to the client registration extension methods, more flexible HTTP client configuration, and updates to the client generation pipeline to support pattern-based OpenAPI spec paths.

**Enhancements to Kiota client registration and HTTP client configuration:**

* Added a new overload of `RegisterKiotaClient<TClient>` in `KiotaMiddlewareExtensions.cs` that allows registration using a `Func<IServiceProvider, Uri>` for dynamic endpoint configuration and optional default headers. This provides more flexibility in how clients are registered and configured.
* Introduced a new `AddConfiguredHttpClient<TClient>` method that supports configuring the HTTP client for a Kiota client using a factory for the base URI and optional headers, improving testability and configuration options.

**Pipeline and client generation improvements:**

* Updated the `openApiSpecPath` parameters in `KiotaClientGeneration.yml` to use glob patterns (`**/filename.yaml`), allowing the pipeline to find OpenAPI spec files in any subdirectory, which increases robustness and flexibility in spec file organization. [[1]](diffhunk://#diff-752aabb0fd5e77563d7645bf03f77403a22ccaceba3fb422ce04c69208f0e551L5-R5) [[2]](diffhunk://#diff-752aabb0fd5e77563d7645bf03f77403a22ccaceba3fb422ce04c69208f0e551L14-R14) [[3]](diffhunk://#diff-752aabb0fd5e77563d7645bf03f77403a22ccaceba3fb422ce04c69208f0e551L23-R23)
* Commented out the checkout step for the OpenAPI spec repo in `KiotaGenerateClients.yml`, possibly to defer repository checkout or because it's handled elsewhere.