### PR TITLE
Pack Common project

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,6 +118,13 @@ stages:
         arguments: '--configuration $(BuildConfiguration) --settings "$(Build.SourcesDirectory)\test.runsettings" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --no-restore'
 
     - task: DotNetCoreCLI@2
+      displayName: Pack Common
+      inputs:
+        command: custom
+        custom: pack
+        arguments: $(Build.SourcesDirectory)\src\UKHO.ADDS.Clients.Common\UKHO.ADDS.Clients.Common.csproj --configuration $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)\packages --verbosity normal
+
+    - task: DotNetCoreCLI@2
       displayName: Pack FileShareService.ReadOnly
       inputs:
         command: custom


### PR DESCRIPTION
#### PR Classification
Pipeline enhancement to automate packaging of a shared project.

#### PR Summary
This pull request updates the Azure Pipelines configuration to include packaging for the UKHO.ADDS.Clients.Common project.
- azure-pipelines.yml: Added a DotNetCoreCLI@2 task to pack UKHO.ADDS.Clients.Common.csproj and output the package to the artifact staging directory before existing pack tasks.
